### PR TITLE
fix: support Path type

### DIFF
--- a/lib/agent-skills.nix
+++ b/lib/agent-skills.nix
@@ -45,7 +45,7 @@ let
   # Recursively search for SKILL.md directories up to `maxDepth`.
   discoverSource = name: cfg:
     let
-      skillsRoot' = resolveSourceRoot name cfg + "/${cfg.subdir or "/."}";
+      skillsRoot' = resolveSourceRoot name cfg + "/${cfg.subdir or "."}";
       skillsRoot = if !pathExists skillsRoot' then
         throw "agent-skills: source ${name} subdir ${toString skillsRoot'} does not exist"
       else skillsRoot';

--- a/lib/agent-skills.nix
+++ b/lib/agent-skills.nix
@@ -45,10 +45,10 @@ let
   # Recursively search for SKILL.md directories up to `maxDepth`.
   discoverSource = name: cfg:
     let
-      skillsRoot = resolveSourceRoot name cfg + "/" + (cfg.subdir or ".");
-      _ = if !pathExists skillsRoot then
-        throw "agent-skills: source ${name} subdir ${skillsRoot} does not exist"
-      else null;
+      skillsRoot' = resolveSourceRoot name cfg + "/${cfg.subdir or "/."}";
+      skillsRoot = if !pathExists skillsRoot' then
+        throw "agent-skills: source ${name} subdir ${toString skillsRoot'} does not exist"
+      else skillsRoot';
 
       maxDepth = cfg.filter.maxDepth or 1;
       nameRegex = cfg.filter.nameRegex or null;
@@ -76,7 +76,7 @@ let
 
           deeper =
             if depth < maxDepth then
-              concatMap (n: scan (path + "/" + n) (relParts ++ [ n ]) (depth + 1)) dirs
+              concatMap (n: scan (path + "/${n}") (relParts ++ [ n ]) (depth + 1)) dirs
             else [];
         in current ++ deeper;
 

--- a/modules/home-manager/agent-skills.nix
+++ b/modules/home-manager/agent-skills.nix
@@ -7,7 +7,7 @@ let
       inputs = inputs // inputsFromArgs;
     };
 in
-{ config, pkgs, ... }@args:
+{ config, pkgs, lib, ... }@args:
 let
   cfg = config.programs.agent-skills;
   agentLib = agentLibFor (args.inputs or {});


### PR DESCRIPTION
This PR makes three modifications.

1. fix homaManagerModules.default to use `lib` from home-manager, instead of nixpkgs.
    `lib.hm` exists only in `lib` from home-manager.
2. fix throwing when `skillsRoot` does not exist.
    nix evaluates variables lazily, so variables which is not referenced is not evaluated.
3. fix path concatenation.
    `path + "/" + subdir` becomes `${path}${subdir}`. this comes from the Path type handling in nix evaluation.