### PR TITLE
feat(targets): support CLAUDE_CONFIG_DIR and CODEX_HOME environment variables

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,18 @@
       agentLib = import ./lib/agent-skills.nix { inherit lib inputs; };
 
       defaultTargets = {
-        codex = { dest = ".codex/skills"; structure = "symlink-tree"; enable = true; systems = []; };
-        claude = { dest = ".claude/skills"; structure = "symlink-tree"; enable = true; systems = []; };
+        codex = {
+          dest = "\${CODEX_HOME:-$HOME/.codex}/skills";
+          structure = "symlink-tree";
+          enable = true;
+          systems = [];
+        };
+        claude = {
+          dest = "\${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills";
+          structure = "symlink-tree";
+          enable = true;
+          systems = [];
+        };
       };
 
       defaultConfig = {
@@ -56,7 +66,7 @@
 
       defaultDests = system:
         builtins.concatStringsSep " "
-          (map (t: "$HOME/${t.dest}") (builtins.attrValues (targetsFor system)));
+          (map (t: t.dest) (builtins.attrValues (targetsFor system)));
 
       bundleFor = system:
         let pkgs = nixpkgs.legacyPackages.${system}; in

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -22,7 +22,15 @@ let
 
       dest = lib.mkOption {
         type = lib.types.str;
-        description = "Destination relative to $HOME (e.g. .codex/skills).";
+        description = ''
+          Destination path for skills. Supports shell variable expansion at runtime.
+          Examples:
+            - ".codex/skills" (relative to $HOME, legacy style)
+            - "''${CODEX_HOME:-$HOME/.codex}/skills" (with environment variable)
+            - "''${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills" (with environment variable)
+          Note: 'link' structure type does not support shell variable expansion;
+          use 'symlink-tree' or 'copy-tree' for dynamic paths.
+        '';
       };
 
       structure = lib.mkOption {


### PR DESCRIPTION
## Summary

- Support shell variable expansion in `dest` option for runtime path customisation
- Default targets now use `${CODEX_HOME:-$HOME/.codex}/skills` and `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills`
- Users with `CLAUDE_CONFIG_DIR` or `CODEX_HOME` environment variables set will have skills installed to their custom locations automatically

## Breaking Change

Default target destinations now use environment variable expansion syntax. However, existing custom targets using relative paths like `.codex/skills` will continue to work unchanged.

## Changes

- **modules/common.nix**: Update `dest` option description to document shell variable expansion support
- **flake.nix**: Update default targets to use environment variable expansion with fallbacks
- **modules/home-manager/agent-skills.nix**: 
  - Simplify sync script to use `dest` directly
  - Handle `link` structure type by extracting fallback path from shell variable syntax (since `home.file` requires static paths)
- **README.md**: Update documentation with new configuration examples

## Usage

Users can set `CLAUDE_CONFIG_DIR` or `CODEX_HOME` environment variables to customise where skills are installed:

```bash
export CLAUDE_CONFIG_DIR="$HOME/.config/claude"
export CODEX_HOME="$HOME/.config/codex"
```

Or configure custom targets in their flake:

```nix
programs.agent-skills.targets = {
  claude = {
    dest = "\${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills";
    structure = "symlink-tree";
  };
};
```

## Test plan

- [x] `nix flake check` passes
- [ ] Test with `CLAUDE_CONFIG_DIR` set to a custom path
- [ ] Test with default configuration (no env vars set)