### PR TITLE
feat: add local skills installation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Nix build outputs
+result
+result-*

--- a/README.md
+++ b/README.md
@@ -77,11 +77,12 @@ Notes:
 ## Flake outputs
 
 - `packages.<system>.agent-skills-bundle`: Store bundle of selected skills (empty by default; configure in consumers).
-- `apps.<system>.skills-install`: Sync bundle to default targets (`$HOME/.codex/skills`, `$HOME/.claude/skills`). Override destinations with `AGENT_SKILLS_DESTS`.
+- `apps.<system>.skills-install`: Sync bundle to global targets (`$HOME/.codex/skills`, `$HOME/.claude/skills`). Override destinations with `AGENT_SKILLS_DESTS`.
+- `apps.<system>.skills-install-local`: Sync bundle to local targets (`.codex/skills`, `.claude/skills` relative to current directory). Override root with `AGENT_SKILLS_ROOT`, destinations with `AGENT_SKILLS_LOCAL_DESTS`.
 - `apps.<system>.skills-list`: JSON view of the default catalog.
 - `checks.<system>.skills`: Sanity check that the bundle builds.
 - `homeManagerModules.default`: Home Manager module implementing the DSL above.
-- `lib.agent-skills`: Helper functions (`discoverCatalog`, `selectSkills`, `mkBundle`, `catalogJson`, `defaultConfig`).
+- `lib.agent-skills`: Helper functions (`discoverCatalog`, `selectSkills`, `mkBundle`, `mkLocalInstallScript`, `mkShellHook`, `catalogJson`, `defaultConfig`).
 
 ## Library functions
 
@@ -98,10 +99,89 @@ in { inherit catalog selection bundle; }
 
 ## Apps usage
 
-- List catalog: `nix run .#skills-list`
-- Sync bundle: `nix run .#skills-install` (override destinations via `AGENT_SKILLS_DESTS="~/tmp/skills1 ~/tmp/skills2"`)
+### Global skills (Home Manager)
 
-Both apps operate on the flake’s default (empty) config; point at your own flake/module for real catalogs.
+- List catalog: `nix run .#skills-list`
+- Sync bundle to `$HOME`: `nix run .#skills-install` (override destinations via `AGENT_SKILLS_DESTS="~/tmp/skills1 ~/tmp/skills2"`)
+
+### Local skills (project-local)
+
+- Sync bundle to current directory: `nix run .#skills-install-local`
+
+Local skills are installed to `.claude/skills` and `.codex/skills` relative to the current working directory (or `AGENT_SKILLS_ROOT` if set). Override destinations via `AGENT_SKILLS_LOCAL_DESTS`.
+
+Both apps operate on the flake's default (empty) config; point at your own flake/module for real catalogs.
+
+## Local skills in your project
+
+To install skills locally in your project, use `mkLocalInstallScript` in your flake:
+
+```nix
+{
+  inputs = {
+    agent-skills.url = "github:Kyure-A/agent-skills-nix";
+    anthropic-skills.url = "github:anthropics/skills";
+    anthropic-skills.flake = false;
+  };
+
+  outputs = { self, nixpkgs, agent-skills, anthropic-skills, ... }:
+    let
+      system = "x86_64-linux";  # or your system
+      pkgs = nixpkgs.legacyPackages.${system};
+      agentLib = agent-skills.lib.agent-skills;
+
+      sources = {
+        anthropic = {
+          path = anthropic-skills;
+          subdir = "skills";
+        };
+      };
+
+      catalog = agentLib.discoverCatalog sources;
+      allowlist = agentLib.allowlistFor {
+        inherit catalog sources;
+        enable = [ "frontend-design" "skill-creator" ];
+      };
+      selection = agentLib.selectSkills {
+        inherit catalog allowlist sources;
+        skills = {};
+      };
+      bundle = agentLib.mkBundle { inherit pkgs selection; };
+    in {
+      apps.${system}.skills-install-local = {
+        type = "app";
+        program = "${agentLib.mkLocalInstallScript { inherit pkgs bundle; }}/bin/skills-install-local";
+      };
+    };
+}
+```
+
+Then run `nix run .#skills-install-local` from your project root to install skills to `.claude/skills` and `.codex/skills`.
+
+### Auto-install with devShell
+
+Use `mkShellHook` to automatically install skills when entering a dev shell:
+
+```nix
+{
+  # ... same inputs and setup as above ...
+
+  outputs = { self, nixpkgs, agent-skills, anthropic-skills, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      agentLib = agent-skills.lib.agent-skills;
+
+      # ... sources, catalog, selection, bundle setup ...
+    in {
+      devShells.${system}.default = pkgs.mkShell {
+        shellHook = agentLib.mkShellHook { inherit pkgs bundle; };
+      };
+    };
+}
+```
+
+Now `nix develop` will automatically install skills to your project directory.
 
 ## Checks / safety
 

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
       };
 
       # Local targets: installed to project root (current working directory)
-      # TODO: Update to use CODEX_HOME/CLAUDE_CONFIG_DIR when #3 is merged
+      # Uses relative paths for project-local installation (not global env vars).
       defaultLocalTargets = {
         codex = { dest = ".codex/skills"; structure = "copy-tree"; enable = true; systems = []; };
         claude = { dest = ".claude/skills"; structure = "copy-tree"; enable = true; systems = []; };

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       forAllSystems = lib.genAttrs systems;
       agentLib = import ./lib/agent-skills.nix { inherit lib inputs; };
 
-      # Global targets: installed to $HOME
+      # Global targets: respects CODEX_HOME/CLAUDE_CONFIG_DIR environment variables.
       defaultTargets = {
         codex = {
           dest = "\${CODEX_HOME:-$HOME/.codex}/skills";

--- a/lib/agent-skills.nix
+++ b/lib/agent-skills.nix
@@ -205,7 +205,7 @@ let
     }) catalog;
 
   # Default local targets for project-local skill installation.
-  # TODO: Update to use CODEX_HOME/CLAUDE_CONFIG_DIR when #3 is merged
+  # Uses relative paths for project-local installation (not global env vars).
   defaultLocalTargets = {
     codex = { dest = ".codex/skills"; };
     claude = { dest = ".claude/skills"; };

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/bna4m143q56hzqw06dz6a71w806g37fc-agent-skills-test-bundle

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/bna4m143q56hzqw06dz6a71w806g37fc-agent-skills-test-bundle


### PR DESCRIPTION
## Summary

Add support for installing skills to project-local directories (`.claude/skills`, `.codex/skills` relative to PWD) in addition to global installation (`$HOME`).

## Changes

- **flake.nix**: Add `defaultLocalTargets` configuration and `skills-install-local` app
- **lib/agent-skills.nix**: Add `mkLocalInstallScript` and `defaultLocalTargets` to lib for use in consumer flakes
- **README.md**: Add local skills documentation and usage examples

## Environment Variables

- `AGENT_SKILLS_ROOT`: Override project root (default: `$PWD`)
- `AGENT_SKILLS_LOCAL_DESTS`: Override local destinations

## Usage

```bash
# Install skills to current directory
nix run .#skills-install-local

# Install to specific directory
AGENT_SKILLS_ROOT=/path/to/project nix run .#skills-install-local
```

For consumer flakes, use `mkLocalInstallScript`:

```nix
apps.${system}.skills-install-local = {
  type = "app";
  program = "${agentLib.mkLocalInstallScript { inherit pkgs bundle; }}/bin/skills-install-local";
};
```

## Test plan

- [x] `nix flake check` passes
- [x] Test `nix run .#skills-install-local` installs to `.claude/skills` and `.codex/skills`
- [x] Test `AGENT_SKILLS_ROOT` override works