### PR TITLE
chore: unify app and home manager settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Then load it from your main Home Manager config:
     enable = true;
     # Default targets use CODEX_HOME and CLAUDE_CONFIG_DIR environment variables
     # with fallback to $HOME/.codex and $HOME/.claude respectively.
-    # Custom targets can be configured as follows:
+    # Omit targets to use the defaults; customize or disable as needed:
     targets = {
       codex  = {
         dest = "\${CODEX_HOME:-$HOME/.codex}/skills";
@@ -80,6 +80,7 @@ Notes:
 
 - If you use a child flake, import both modules: `inputs.agent-skills.homeManagerModules.default` and `inputs.skills-config.homeManagerModules.default`.
 - Pass your flake `inputs` to Home Manager (e.g. `home-manager.extraSpecialArgs = { inherit inputs; };`) so source `input` names resolve.
+- To disable a default target, set `targets.<name>.enable = false;` (e.g. `targets.codex.enable = false;`).
 - `structure = "link"` uses `home.file` symlinks; `symlink-tree` and `copy-tree` run in `home.activation`.
 - `symlink-tree` uses `rsync -a --delete` (preserve symlinks); `copy-tree` uses `rsync -aL --delete` (dereference symlinks).
 - `dest` supports shell variable expansion at runtime (e.g. `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills`). Note: `link` structure does not support shell variables and will use the fallback path.
@@ -88,7 +89,7 @@ Notes:
 
 - `packages.<system>.agent-skills-bundle`: Store bundle of selected skills (empty by default; configure in consumers).
 - `apps.<system>.skills-install`: Sync bundle to global targets (respects `CODEX_HOME` and `CLAUDE_CONFIG_DIR` environment variables, with fallback to `$HOME/.codex/skills` and `$HOME/.claude/skills`). Override destinations with `AGENT_SKILLS_DESTS`.
-- `apps.<system>.skills-install-local`: Sync bundle to local targets (`.codex/skills`, `.claude/skills` relative to current directory). Override root with `AGENT_SKILLS_ROOT`, destinations with `AGENT_SKILLS_LOCAL_DESTS`.
+- `apps.<system>.skills-install-local`: Sync bundle to local targets (default `.codex/skills`, `.claude/skills` with `copy-tree`). Override root with `AGENT_SKILLS_ROOT`, destinations with `AGENT_SKILLS_LOCAL_DESTS`.
 - `apps.<system>.skills-list`: JSON view of the default catalog.
 - `checks.<system>.skills`: Sanity check that the bundle builds.
 - `homeManagerModules.default`: Home Manager module implementing the DSL above.
@@ -119,6 +120,8 @@ in { inherit catalog selection bundle; }
 - Sync bundle to current directory: `nix run .#skills-install-local`
 
 Local skills are installed to `.claude/skills` and `.codex/skills` relative to the current working directory (or `AGENT_SKILLS_ROOT` if set). Override destinations via `AGENT_SKILLS_LOCAL_DESTS`.
+Targets respect `enable`, `systems`, and `structure` (default `copy-tree`). To exclude Codex, disable the target or provide custom targets to `mkLocalInstallScript`.
+Local install skips non-Nix-managed existing paths to avoid clobbering user data; set `AGENT_SKILLS_FORCE=1` to overwrite.
 
 Both apps operate on the flake's default (empty) config; point at your own flake/module for real catalogs.
 

--- a/flake.nix
+++ b/flake.nix
@@ -53,13 +53,6 @@
         sources = defaultConfig.sources;
       };
 
-      targetsFor = system:
-        agentLib.targetsFor { targets = defaultTargets; inherit system; };
-
-      defaultDests = system:
-        builtins.concatStringsSep " "
-          (map (t: t.dest) (builtins.attrValues (targetsFor system)));
-
       bundleFor = system:
         let pkgs = nixpkgs.legacyPackages.${system}; in
         agentLib.mkBundle { inherit pkgs; selection = defaultSelection; name = "agent-skills-bundle"; };
@@ -76,28 +69,17 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
           bundle = bundleFor system;
-          dests = defaultDests system;
           listJson = pkgs.writeText "agent-skills-catalog.json" (builtins.toJSON (agentLib.catalogJson defaultCatalog));
 
           installScript = pkgs.writeShellApplication {
             name = "skills-install";
             runtimeInputs = [ pkgs.rsync pkgs.coreutils ];
-            text = ''
-              dests="${dests}"
-              if [ -n "$AGENT_SKILLS_DESTS" ]; then
-                dests="$AGENT_SKILLS_DESTS"
-              fi
-              bundle=${bundle}
-              if [ ! -d "$bundle" ]; then
-                echo "agent-skills: bundle not built" >&2
-                exit 1
-              fi
-              for dest in $dests; do
-                if [ -z "$dest" ]; then continue; fi
-                mkdir -p "$dest"
-                ${pkgs.rsync}/bin/rsync -a --delete "${bundle}/" "$dest/"
-              done
-            '';
+            text = agentLib.mkSyncScript {
+              inherit pkgs bundle;
+              targets = defaultTargets;
+              system = pkgs.system;
+              allowOverrides = true;
+            };
           };
 
           listScript = pkgs.writeShellApplication {

--- a/flake.nix
+++ b/flake.nix
@@ -22,20 +22,7 @@
       agentLib = import ./lib/agent-skills.nix { inherit lib inputs; };
 
       # Global targets: respects CODEX_HOME/CLAUDE_CONFIG_DIR environment variables.
-      defaultTargets = {
-        codex = {
-          dest = "\${CODEX_HOME:-$HOME/.codex}/skills";
-          structure = "symlink-tree";
-          enable = true;
-          systems = [];
-        };
-        claude = {
-          dest = "\${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills";
-          structure = "symlink-tree";
-          enable = true;
-          systems = [];
-        };
-      };
+      defaultTargets = agentLib.defaultTargets;
 
       # Local targets: installed to project root (current working directory)
       # Uses relative paths for project-local installation (not global env vars).

--- a/lib/agent-skills.nix
+++ b/lib/agent-skills.nix
@@ -204,6 +204,23 @@ let
       meta = skill.meta or {};
     }) catalog;
 
+  # Default global targets for user-level installation.
+  # Respects CODEX_HOME and CLAUDE_CONFIG_DIR environment variables.
+  defaultTargets = {
+    codex = {
+      dest = "\${CODEX_HOME:-$HOME/.codex}/skills";
+      structure = "symlink-tree";
+      enable = true;
+      systems = [];
+    };
+    claude = {
+      dest = "\${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills";
+      structure = "symlink-tree";
+      enable = true;
+      systems = [];
+    };
+  };
+
   # Default local targets for project-local skill installation.
   # Uses relative paths for project-local installation (not global env vars).
   defaultLocalTargets = {
@@ -290,5 +307,6 @@ in
   catalogJson = catalogJson;
   mkLocalInstallScript = mkLocalInstallScript;
   mkShellHook = mkShellHook;
+  defaultTargets = defaultTargets;
   defaultLocalTargets = defaultLocalTargets;
 }

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -159,7 +159,7 @@ in
 
     targets = lib.mkOption {
       type = lib.types.attrsOf targetType;
-      default = {};
+      default = agentLib.defaultTargets;
       description = "Agent-specific sync destinations.";
     };
 


### PR DESCRIPTION
This pull request refactors how skill installation targets are managed and synced in both the flake and library code. It centralizes default target definitions, improves configurability (including enabling/disabling and structure selection), and introduces more robust, flexible sync scripts for both global and local installations. The documentation is updated to reflect these changes, clarifying usage and customization options.

**Target management and configuration:**
- Moved the definitions of `defaultTargets` and `defaultLocalTargets` from `flake.nix` into `lib/agent-skills.nix`, centralizing and exposing them for reuse and consistency. (`flake.nix`, `lib/agent-skills.nix`) [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L25-R29) [[2]](diffhunk://#diff-7e2a9d3d912d08726d4b40b776270f3ef1addc758d406ce623f8f149a3e66225R207-R265) [[3]](diffhunk://#diff-7e2a9d3d912d08726d4b40b776270f3ef1addc758d406ce623f8f149a3e66225R454-R456)
- The Home Manager module now defaults the `targets` option to `agentLib.defaultTargets`, ensuring consistent defaults. (`modules/common.nix`)

**Sync script improvements:**
- Introduced the `mkSyncScript` function in `lib/agent-skills.nix` for generating robust, structure-aware sync scripts for both global and local installs, supporting overrides via environment variables. (`lib/agent-skills.nix`) [[1]](diffhunk://#diff-7e2a9d3d912d08726d4b40b776270f3ef1addc758d406ce623f8f149a3e66225R302-R435) [[2]](diffhunk://#diff-7e2a9d3d912d08726d4b40b776270f3ef1addc758d406ce623f8f149a3e66225R454-R456)
- Refactored the Home Manager module and flake outputs to use the new `mkSyncScript` and `mkLocalInstallScript` functions, reducing code duplication and improving maintainability. (`flake.nix`, `modules/home-manager/agent-skills.nix`) [[1]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L102-R82) [[2]](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L134-R95) [[3]](diffhunk://#diff-8f371b0600354e4220fc1ad6d27852e2d9bd649592edfa441f69287fead4f35aL20-R24)

**Documentation updates:**
- Updated `README.md` to clarify how to customize or disable targets, how local/global installs work, and how to use the new features (such as disabling targets and respecting structure/enable filters). (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R64) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R83) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R92) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R123-R124)

**Behavioral improvements:**
- Local install scripts now respect the `enable`, `systems`, and `structure` attributes for each target, and avoid overwriting non-Nix-managed paths unless forced. (`lib/agent-skills.nix`)

**Code cleanup:**
- Removed now-redundant helper functions and script text from `flake.nix`, delegating to the new library functions for target filtering and script generation. (`flake.nix`)