### PR TITLE
fix(home-manager): add packages and transform options to skillType

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,9 @@
             mkdir -p "$out"
             touch "$out/ok"
           '';
+          transform-packages = import ./test/transform-packages.nix {
+            inherit pkgs agentLib;
+          };
         });
 
       homeManagerModules.default =

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -114,6 +114,18 @@ let
         default = {};
         description = "Optional metadata override.";
       };
+
+      packages = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
+        default = [];
+        description = "Packages to symlink into the skill directory.";
+      };
+
+      transform = lib.mkOption {
+        type = lib.types.nullOr lib.types.raw;
+        default = null;
+        description = "Function to transform SKILL.md content: { original, dependencies } -> string.";
+      };
     };
   });
 in


### PR DESCRIPTION
## Summary

- Add `packages` and `transform` options to `skillType` in `modules/common.nix`
- Add `transform-packages` test to flake checks

## Problem

The `lib/agent-skills.nix` already supports `packages` and `transform` in `selectSkills`, but the Home Manager module was missing these option definitions in `skillType`. This prevented users from using these features via `skills.explicit` configuration.

The README documents these options, but they weren't actually available through the module interface.

## Changes

- Added `packages` option (type: `listOf package`, default: `[]`)
- Added `transform` option (type: `nullOr raw`, default: `null`)
- Added existing `transform-packages.nix` test to flake checks for CI validation

## Test plan

- [x] `nix flake check` passes
- [x] Existing `transform-packages.nix` tests cover the lib functionality