### PR TITLE
fix(lib): allow null transform in explicit skills

### DIFF
--- a/lib/agent-skills.nix
+++ b/lib/agent-skills.nix
@@ -205,7 +205,7 @@ let
               throw "agent-skills: skill ${name} path ${absPath} does not exist"
             else if !pathExists (absPath + "/SKILL.md") then
               throw "agent-skills: skill ${name} at ${absPath} is missing SKILL.md"
-            else if cfg ? transform && !isFunction cfg.transform then
+            else if cfg ? transform && cfg.transform != null && !isFunction cfg.transform then
               throw "agent-skills: skill ${name} transform must be a function, got ${builtins.typeOf cfg.transform}"
             else true;
           id = assertSkillId (cfg.rename or name);


### PR DESCRIPTION
## Summary

Fix validation to allow `null` transform values when using Home Manager module.

## Problem

When using the Home Manager module with `skills.explicit`, the `transform` option defaults to `null`. The validation was incorrectly rejecting `null` values because it only checked if the attribute exists (`cfg ? transform`), not whether it was actually set to a non-null value.

This caused the error:
```
agent-skills: skill X transform must be a function, got null
```

## Fix

Changed the validation from:
```nix
cfg ? transform && !isFunction cfg.transform
```

To:
```nix
cfg ? transform && cfg.transform != null && !isFunction cfg.transform
```

## Test plan

- [x] `nix flake check` passes
- [x] Existing transform-packages tests still pass