### PR TITLE
fix(lib): place dependencies after original content

### DIFF
--- a/lib/agent-skills.nix
+++ b/lib/agent-skills.nix
@@ -253,12 +253,13 @@ let
           originalContent = readFile (skillPath + "/SKILL.md");
           packagesTable = mkPackagesTable (skill.packages or []);
 
-          # Apply transform function or use default (dependencies + original)
+          # Apply transform function or use default (original + dependencies at end)
+          # This preserves frontmatter at the start of the file
           transformedContent =
             if hasTransform then
               skill.transform { original = originalContent; dependencies = packagesTable; }
             else
-              packagesTable + originalContent;
+              originalContent + "\n" + packagesTable;
         in
         if needsCustomisation then
           let

--- a/test/transform-packages.nix
+++ b/test/transform-packages.nix
@@ -159,10 +159,10 @@ pkgs.runCommand "agent-skills-transform-packages-test" {} ''
   # Check original content is included
   grep -q "# Test Skill" "$skillMd2" || { echo "Original content not found"; exit 1; }
 
-  # Check order: Dependencies -> Original
+  # Check order: Original -> Dependencies (preserves frontmatter)
   deps_line=$(grep -n "## Dependencies" "$skillMd2" | head -1 | cut -d: -f1)
   original_line=$(grep -n "# Test Skill" "$skillMd2" | head -1 | cut -d: -f1)
-  test "$deps_line" -lt "$original_line" || { echo "Dependencies should come before original"; exit 1; }
+  test "$original_line" -lt "$deps_line" || { echo "Original should come before Dependencies"; exit 1; }
 
   echo "Case 2 passed!"
 


### PR DESCRIPTION
## Summary

Place dependencies table after original SKILL.md content instead of before.

## Problem

When using `packages` without a custom `transform` function, the dependencies table was prepended to the SKILL.md content:

```markdown
## Dependencies

| Package | Path |
|---------|------|
| ast-grep | `./ast-grep` |

---
name: my-skill
description: ...
---

# My Skill
...
```

This breaks YAML frontmatter since it must be at the very start of the file for parsers to recognise it.

## Fix

Changed the default behaviour to append dependencies at the end:

```markdown
---
name: my-skill
description: ...
---

# My Skill
...

## Dependencies

| Package | Path |
|---------|------|
| ast-grep | `./ast-grep` |
```

Users can still customise the placement using the `transform` option.

## Test plan

- [x] `nix flake check` passes
- [x] Updated test expectations to match new behaviour