### PR TITLE
fix(module): allow partial target overrides without losing defaults

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -126,6 +126,9 @@
           transform-packages = import ./test/transform-packages.nix {
             inherit pkgs agentLib;
           };
+          targets = import ./test/targets.nix {
+            inherit pkgs agentLib;
+          };
         });
 
       homeManagerModules.default =

--- a/test/targets.nix
+++ b/test/targets.nix
@@ -1,0 +1,31 @@
+# Test targets default merging behaviour
+{ pkgs, agentLib }:
+
+pkgs.runCommand "agent-skills-targets-test" {} ''
+  set -e
+
+  echo "=== Testing targetsFor with default targets ==="
+
+  # Test that default targets include all three targets
+  ${pkgs.lib.concatMapStringsSep "\n" (name: ''
+    echo "Checking default target: ${name}"
+    test "${agentLib.defaultTargets.${name}.dest}" != "" || { echo "Missing dest for ${name}"; exit 1; }
+    test "${agentLib.defaultTargets.${name}.structure}" = "symlink-tree" || { echo "Wrong structure for ${name}"; exit 1; }
+  '') ["claude" "codex" "opencode"]}
+
+  echo ""
+  echo "=== Testing targetsFor filtering ==="
+
+  # Test that targetsFor filters correctly
+  # All targets enabled by default
+  ${let
+    activeTargets = agentLib.targetsFor { targets = agentLib.defaultTargets; system = pkgs.system; };
+  in ''
+    test "${toString (builtins.length (builtins.attrNames activeTargets))}" = "3" || { echo "Expected 3 active targets"; exit 1; }
+  ''}
+
+  echo ""
+  echo "All targets tests passed!"
+  mkdir -p "$out"
+  touch "$out/ok"
+''


### PR DESCRIPTION
## Summary

Allow users to partially override individual target settings without specifying all required options or losing other default targets.

## Problem

Previously, setting `targets.opencode.enable = false` would cause an error:

```
error: The option `programs.agent-skills.targets.opencode.dest' was accessed but has no value defined.
```

This happened because:
1. The `dest` option has no default value (it varies by target name)
2. Setting any attribute on a target creates a new attrset that doesn't inherit from `defaultTargets`

## Solution

1. **Dynamic `dest` default**: The `targetType` submodule now looks up the default `dest` value from `defaultTargets` based on the target name
2. **Merge defaults in config**: Use `lib.mkDefault` to set default targets, allowing user settings to override them properly

## Usage

Now users can simply disable individual targets:

```nix
programs.agent-skills.targets.opencode.enable = false;
```

Or override specific settings while keeping others:

```nix
programs.agent-skills.targets.claude = {
  structure = "link";  # Change structure
  # dest is inherited from defaultTargets
};
```

## Test plan

- [x] `nix flake check` passes
- [x] Added `test/targets.nix` for targets behaviour
- [x] Tested with dotfiles repo that `targets.opencode.enable = false` works correctly