### PR TITLE
feat: excludePatterns オプションの追加（Codex .system 問題の修正）

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
           explicit = {};
         };
         targets = defaultTargets;
+        excludePatterns = agentLib.defaultExcludePatterns;
       };
 
       defaultCatalog = agentLib.discoverCatalog defaultConfig.sources;

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -180,6 +180,17 @@ in
       description = "Agent-specific sync destinations.";
     };
 
+    excludePatterns = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = agentLib.defaultExcludePatterns;
+      description = ''
+        Patterns to exclude from rsync synchronization.
+        Default excludes ".system" to allow agents (Codex, etc.) to manage their own system skills.
+        Set to [] for full declarative control over the skills directory.
+      '';
+      example = [ ".system" ".cache" ];
+    };
+
     catalog = lib.mkOption {
       type = lib.types.attrs;
       description = "Discovered skills catalog.";

--- a/modules/home-manager/agent-skills.nix
+++ b/modules/home-manager/agent-skills.nix
@@ -21,6 +21,7 @@ let
     inherit pkgs bundle;
     targets = syncTargets;
     system = pkgs.system;
+    excludePatterns = cfg.excludePatterns;
   };
 in
 {


### PR DESCRIPTION
## 問題

Codex CLI が `~/.codex/skills/.system/` にシステムスキル（skill-creator, skill-installer 等）をインストールしようとすると、以下のエラーが発生する：

```
codex_core::skills::manager: failed to install system skills: io error while create system skills dir: Permission denied (os error 13)
```

原因：
1. `rsync --delete` が `.system` ディレクトリを削除してしまう
2. rsync 後のディレクトリが read-only (`dr-xr-xr-x`) になり、Codex が書き込めない

## 解決策

### 1. `excludePatterns` オプションの追加

rsync の `--exclude` パターンを設定可能にした

```nix
programs.agent-skills = {
  excludePatterns = [ "/.system" ];  # デフォルト
  # excludePatterns = [];  # 完全宣言的にしたい場合
};
```

- デフォルト: `[ "/.system" ]`（トップレベルの .system のみ除外）
- 先頭の `/` でルート限定（スキル内の .system は除外しない）

### 2. `chmod u+w` の追加

rsync 後にディレクトリに書き込み権限を付与し、Codex が `.system` を作成できるようにした

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `lib/agent-skills.nix` | `defaultExcludePatterns` 追加、rsync に `--exclude` と `chmod u+w` 追加 |
| `modules/common.nix` | `excludePatterns` オプション追加 |
| `modules/home-manager/agent-skills.nix` | `excludePatterns` を `mkSyncScript` に渡す |
| `flake.nix` | `defaultConfig` に `excludePatterns` 追加 |

## テスト

- [x] `nix flake check` 通過
- [x] 実環境で `dr` 後に Codex の Permission denied エラーが解消
- [x] `~/.codex/skills/.system/` に Codex がシステムスキルを作成できることを確認