### PR TITLE
feat!: migrate to .agents/skills directory structure

### DIFF
--- a/lib/agent-skills.nix
+++ b/lib/agent-skills.nix
@@ -305,11 +305,11 @@ SKILL_EOF
     }) catalog;
 
   # Default global targets for user-level installation.
-  # Respects CODEX_HOME and CLAUDE_CONFIG_DIR environment variables.
-  # OpenCode defaults to $HOME/.config/opencode/skills.
+  # Respects CLAUDE_CONFIG_DIR environment variable for Claude Code.
+  # Uses .agents/skills for agentskills.io standard (Codex, etc.).
   defaultTargets = {
-    codex = {
-      dest = "\${CODEX_HOME:-$HOME/.codex}/skills";
+    agents = {
+      dest = "$HOME/.agents/skills";
       structure = "symlink-tree";
       enable = true;
       systems = [];
@@ -320,20 +320,13 @@ SKILL_EOF
       enable = true;
       systems = [];
     };
-    opencode = {
-      dest = "$HOME/.config/opencode/skills";
-      structure = "symlink-tree";
-      enable = true;
-      systems = [];
-    };
   };
 
   # Default local targets for project-local skill installation.
   # Uses relative paths for project-local installation (not global env vars).
   defaultLocalTargets = {
-    codex = { dest = ".codex/skills"; structure = "copy-tree"; enable = true; systems = []; };
+    agents = { dest = ".agents/skills"; structure = "copy-tree"; enable = true; systems = []; };
     claude = { dest = ".claude/skills"; structure = "copy-tree"; enable = true; systems = []; };
-    opencode = { dest = ".opencode/skills"; structure = "copy-tree"; enable = true; systems = []; };
   };
 
   # Default exclude patterns for rsync synchronization.

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -29,10 +29,9 @@ let
         description = ''
           Destination path for skills. Supports shell variable expansion at runtime.
           Examples:
-            - ".codex/skills" (relative to $HOME, legacy style)
-            - "''${CODEX_HOME:-$HOME/.codex}/skills" (with environment variable)
-            - "''${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills" (with environment variable)
-            - "$HOME/.config/opencode/skills" (OpenCode global skills)
+            - ".agents/skills" (agentskills.io standard for Codex, etc.)
+            - "''${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills" (Claude Code with env var)
+            - "$HOME/.agents/skills" (global agentskills.io standard)
           Note: 'link' structure type does not support shell variable expansion;
           use 'symlink-tree' or 'copy-tree' for dynamic paths.
         '';

--- a/test/targets.nix
+++ b/test/targets.nix
@@ -6,12 +6,12 @@ pkgs.runCommand "agent-skills-targets-test" {} ''
 
   echo "=== Testing targetsFor with default targets ==="
 
-  # Test that default targets include all three targets
+  # Test that default targets include agents and claude
   ${pkgs.lib.concatMapStringsSep "\n" (name: ''
     echo "Checking default target: ${name}"
     test "${agentLib.defaultTargets.${name}.dest}" != "" || { echo "Missing dest for ${name}"; exit 1; }
     test "${agentLib.defaultTargets.${name}.structure}" = "symlink-tree" || { echo "Wrong structure for ${name}"; exit 1; }
-  '') ["claude" "codex" "opencode"]}
+  '') ["agents" "claude"]}
 
   echo ""
   echo "=== Testing targetsFor filtering ==="
@@ -21,7 +21,7 @@ pkgs.runCommand "agent-skills-targets-test" {} ''
   ${let
     activeTargets = agentLib.targetsFor { targets = agentLib.defaultTargets; system = pkgs.system; };
   in ''
-    test "${toString (builtins.length (builtins.attrNames activeTargets))}" = "3" || { echo "Expected 3 active targets"; exit 1; }
+    test "${toString (builtins.length (builtins.attrNames activeTargets))}" = "2" || { echo "Expected 2 active targets"; exit 1; }
   ''}
 
   echo ""


### PR DESCRIPTION
## Summary

Migrate from individual agent targets (codex, opencode) to the unified `.agents/skills` directory following the [agentskills.io](https://agentskills.io) standard.

## What Changed

- Replace `codex` and `opencode` targets with single `agents` target
- Keep `claude` target for Claude Code compatibility  
- Update `defaultTargets` to use `$HOME/.agents/skills`
- Update `defaultLocalTargets` to use `.agents/skills`
- Update all documentation examples and descriptions
- Update test assertions for new target structure

## Why

OpenAI Codex and other agents are moving to the `.agents/skills` standard directory structure. This change aligns with that convention while maintaining backward compatibility for Claude Code users who prefer the `.claude/skills` location.

Reference: 
- https://developers.openai.com/codex/skills/
- https://opencode.ai/docs/skills/