### PR TITLE
ci: add workflow to automate flake.lock updates

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,39 @@
+name: Update flake.lock
+
+on:
+  schedule:
+    # Every Monday at 03:00 UTC
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-flake-lock
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - uses: ./.github/actions/setup-nix
+      - name: Update flake.lock
+        run: nix flake update
+      - name: Run flake check
+        run: nix flake check
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@84ae59a2cdc2258d6fa0732dd66352dddae2a412 # v7.0.9
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(nix): update flake.lock"
+          title: "chore(nix): update flake.lock"
+          body: |
+            Automated flake input update.
+          branch: update/flake-lock
+          base: master
+          delete-branch: true
+          labels: dependencies,automated
+          add-paths: flake.lock


### PR DESCRIPTION
- Schedule weekly updates and allow manual dispatch
- Run flake update and check, then create pull request
- Set permissions and concurrency for safe automation