### PR TITLE
fix: replace deprecated `pkgs.system` with `pkgs.stdenv.hostPlatform.system`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -82,7 +82,7 @@
             text = lib.mkSyncScript {
               inherit pkgs bundle;
               targets = defaultTargets;
-              system = pkgs.system;
+              system = pkgs.stdenv.hostPlatform.system;
               allowOverrides = true;
             };
           };

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -384,7 +384,7 @@ SKILL_EOF
   # Respects target enable/system filters and structure (link/symlink-tree/copy-tree).
   mkLocalInstallScript = { pkgs, bundle, targets ? defaultLocalTargets, excludePatterns ? defaultExcludePatterns }:
     let
-      activeTargets = targetsFor { inherit targets; system = pkgs.system; };
+      activeTargets = targetsFor { inherit targets; system = pkgs.stdenv.hostPlatform.system; };
       targetsList = lib.mapAttrsToList (name: t:
         let
           structure = t.structure or "copy-tree";
@@ -520,7 +520,7 @@ SKILL_EOF
     pkgs,
     bundle,
     targets,
-    system ? pkgs.system,
+    system ? pkgs.stdenv.hostPlatform.system,
     allowOverrides ? false,
     overrideEnvVar ? "AGENT_SKILLS_DESTS",
     overrideStructure ? "symlink-tree",

--- a/modules/home-manager/agent-skills.nix
+++ b/modules/home-manager/agent-skills.nix
@@ -12,7 +12,7 @@ let
   cfg = config.programs.agent-skills;
   agentLib = agentLibFor (args.inputs or {});
 
-  activeTargets = agentLib.targetsFor { targets = cfg.targets; system = pkgs.system; };
+  activeTargets = agentLib.targetsFor { targets = cfg.targets; system = pkgs.stdenv.hostPlatform.system; };
   anyTargetEnabled = lib.any (t: t.enable or false) (builtins.attrValues cfg.targets);
 
   linkTargets = lib.filterAttrs (_: t: t.structure == "link") activeTargets;
@@ -21,7 +21,7 @@ let
   syncScript = bundle: agentLib.mkSyncScript {
     inherit pkgs bundle;
     targets = syncTargets;
-    system = pkgs.system;
+    system = pkgs.stdenv.hostPlatform.system;
     excludePatterns = cfg.excludePatterns;
   };
 in

--- a/test/targets.nix
+++ b/test/targets.nix
@@ -30,7 +30,7 @@ pkgs.runCommand "agent-skills-targets-test" {} ''
   # Test that targetsFor filters correctly
   # All targets are disabled by default
   ${let
-    activeTargets = agentLib.targetsFor { targets = agentLib.defaultTargets; system = pkgs.system; };
+    activeTargets = agentLib.targetsFor { targets = agentLib.defaultTargets; system = pkgs.stdenv.hostPlatform.system; };
   in ''
     test "${toString (builtins.length (builtins.attrNames activeTargets))}" = "0" || { echo "Expected 0 active targets"; exit 1; }
   ''}
@@ -41,7 +41,7 @@ pkgs.runCommand "agent-skills-targets-test" {} ''
       targets = agentLib.defaultTargets // {
         claude = agentLib.defaultTargets.claude // { enable = true; };
       };
-      system = pkgs.system;
+      system = pkgs.stdenv.hostPlatform.system;
     };
   in ''
     test "${toString (builtins.length (builtins.attrNames enabledClaudeTargets))}" = "1" || { echo "Expected 1 active target when only claude is enabled"; exit 1; }


### PR DESCRIPTION
## Summary

- Replace all 7 occurrences of deprecated `pkgs.system` with `pkgs.stdenv.hostPlatform.system`
- Eliminates evaluation warning: `'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`

## Changed files

| File | Occurrences |
|------|-------------|
| `flake.nix` | 1 |
| `lib/default.nix` | 2 |
| `modules/home-manager/agent-skills.nix` | 2 |
| `test/targets.nix` | 2 |

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)