### PR TITLE
feat: add rewriteCommands option to auto-replace command names

### DIFF
--- a/examples/skill-customization/explicit-transform.nix
+++ b/examples/skill-customization/explicit-transform.nix
@@ -1,8 +1,25 @@
 programs.agent-skills.skills.explicit = {
+  # Simple case: packages with automatic command rewriting (default)
+  # All occurrences of "jq" in SKILL.md are rewritten to "./jq"
+  my-tool = {
+    from = "my-source";
+    path = "some-skill";
+    packages = [ pkgs.jq pkgs.curl ];
+  };
+
+  # Disable automatic rewriting if you want bare command names
+  my-tool-no-rewrite = {
+    from = "my-source";
+    path = "some-skill";
+    packages = [ pkgs.jq ];
+    rewriteCommands = false;
+  };
+
+  # Full customisation with transform (rewriteCommands applies before transform)
   my-skill = {
     from = "my-source";
     path = "some-skill";
-    packages = [ pkgs.jq pkgs.curl ]; # Symlinked into skill directory
+    packages = [ pkgs.jq pkgs.curl ];
     transform = { original, dependencies }: ''
       # Custom Header
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -176,6 +176,27 @@ let
         ) packages;
       in header + rows + "\n\n";
 
+  # Rewrite bare command names to ./command paths in content.
+  rewriteCommandPaths = content: packages:
+    let
+      allBinNames = lib.unique (concatMap (pkg:
+        let info = getPkgBinInfo pkg;
+        in if info.isDir then info.binaries else [ info.name ]
+      ) packages);
+    in
+    if allBinNames == [] then content
+    else
+      let
+        rewritten = builtins.replaceStrings
+          allBinNames
+          (map (name: "./${name}") allBinNames)
+          content;
+        fixed = builtins.replaceStrings
+          (map (name: "././${name}") allBinNames)
+          (map (name: "./${name}") allBinNames)
+          rewritten;
+      in fixed;
+
   # Build selection from allowlist + explicit skills.
   selectSkills = { catalog, allowlist ? [], skills ? {}, sources }:
     let
@@ -217,6 +238,7 @@ let
           source = srcName;
           meta = cfg.meta or {};
           transform = cfg.transform or null;
+          rewriteCommands = cfg.rewriteCommands or true;
           packages = cfg.packages or [];
         }
       ) explicit;
@@ -255,13 +277,19 @@ let
           originalContent = readFile (skillPath + "/SKILL.md");
           packagesTable = mkPackagesTable (skill.packages or []);
 
+          # Optionally rewrite bare command names to ./command paths
+          hasRewrite = (skill.rewriteCommands or true) && hasPackages;
+          rewrittenContent =
+            if hasRewrite then rewriteCommandPaths originalContent (skill.packages or [])
+            else originalContent;
+
           # Apply transform function or use default (original + dependencies at end)
           # This preserves frontmatter at the start of the file
           transformedContent =
             if hasTransform then
-              skill.transform { original = originalContent; dependencies = packagesTable; }
+              skill.transform { original = rewrittenContent; dependencies = packagesTable; }
             else
-              originalContent + "\n" + packagesTable;
+              rewrittenContent + "\n" + packagesTable;
         in
         if needsCustomisation then
           let
@@ -626,6 +654,7 @@ in
   targetsFor = targetsFor;
   mkBundle = mkBundle;
   mkPackagesTable = mkPackagesTable;
+  rewriteCommandPaths = rewriteCommandPaths;
   getPkgBinInfo = getPkgBinInfo;
   catalogJson = catalogJson;
   mkLocalInstallScript = mkLocalInstallScript;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -176,12 +176,12 @@ let
         ) packages;
       in header + rows + "\n\n";
 
-  # Rewrite bare command names to ./command paths in content.
+  # Rewrite single-binary package commands to ./command paths in content.
   rewriteCommandPaths = content: packages:
     let
       allBinNames = lib.unique (concatMap (pkg:
         let info = getPkgBinInfo pkg;
-        in if info.isDir then info.binaries else [ info.name ]
+        in if info.isDir then [] else [ info.name ]
       ) packages);
     in
     if allBinNames == [] then content
@@ -238,7 +238,7 @@ let
           source = srcName;
           meta = cfg.meta or {};
           transform = cfg.transform or null;
-          rewriteCommands = cfg.rewriteCommands or true;
+          rewriteCommands = if cfg ? rewriteCommands then cfg.rewriteCommands else true;
           packages = cfg.packages or [];
         }
       ) explicit;
@@ -277,8 +277,8 @@ let
           originalContent = readFile (skillPath + "/SKILL.md");
           packagesTable = mkPackagesTable (skill.packages or []);
 
-          # Optionally rewrite bare command names to ./command paths
-          hasRewrite = (skill.rewriteCommands or true) && hasPackages;
+          # Optionally rewrite single-binary command names to ./command paths.
+          hasRewrite = (if skill ? rewriteCommands then skill.rewriteCommands else true) && hasPackages;
           rewrittenContent =
             if hasRewrite then rewriteCommandPaths originalContent (skill.packages or [])
             else originalContent;

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -125,6 +125,12 @@ let
         description = "Packages to symlink into the skill directory.";
       };
 
+      rewriteCommands = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Automatically rewrite package binary names to ./name paths in SKILL.md content.";
+      };
+
       transform = lib.mkOption {
         type = lib.types.nullOr lib.types.raw;
         default = null;

--- a/test/fixtures/rewrite-skill/SKILL.md
+++ b/test/fixtures/rewrite-skill/SKILL.md
@@ -1,0 +1,9 @@
+# Rewrite Test Skill
+
+Run jq to process JSON:
+
+jq '.key' input.json
+
+You can also pipe: cat file.json | jq '.key'
+
+Already local: ./jq --help

--- a/test/fixtures/rewrite-skill/SKILL.md
+++ b/test/fixtures/rewrite-skill/SKILL.md
@@ -7,3 +7,7 @@ jq '.key' input.json
 You can also pipe: cat file.json | jq '.key'
 
 Already local: ./jq --help
+
+Run bunx for multi-binary package coverage:
+
+bunx --version

--- a/test/transform-packages.nix
+++ b/test/transform-packages.nix
@@ -83,6 +83,44 @@ ${original}
     };
   };
 
+  # Rewrite test sources
+  rewriteSources = {
+    rewrite-fixtures = {
+      path = ./fixtures/rewrite-skill;
+    };
+  };
+
+  rewriteCatalog = agentLib.discoverCatalog rewriteSources;
+
+  # Case 6: rewriteCommands = true (default) with packages
+  testSelectionRewrite = agentLib.selectSkills {
+    catalog = rewriteCatalog;
+    allowlist = [];
+    sources = rewriteSources;
+    skills = {
+      test-skill-rewrite = {
+        from = "rewrite-fixtures";
+        path = ".";
+        packages = [ pkgs.jq ];
+      };
+    };
+  };
+
+  # Case 7: rewriteCommands = false with packages
+  testSelectionRewriteDisabled = agentLib.selectSkills {
+    catalog = rewriteCatalog;
+    allowlist = [];
+    sources = rewriteSources;
+    skills = {
+      test-skill-rewrite-disabled = {
+        from = "rewrite-fixtures";
+        path = ".";
+        packages = [ pkgs.jq ];
+        rewriteCommands = false;
+      };
+    };
+  };
+
   # Case 5: Error case - transform is not a function
   invalidSelection = agentLib.selectSkills {
     catalog = testCatalog;
@@ -121,6 +159,18 @@ ${original}
     inherit pkgs;
     selection = testSelectionTransformOnly;
     name = "agent-skills-test-transform-only";
+  };
+
+  testBundleRewrite = agentLib.mkBundle {
+    inherit pkgs;
+    selection = testSelectionRewrite;
+    name = "agent-skills-test-rewrite";
+  };
+
+  testBundleRewriteDisabled = agentLib.mkBundle {
+    inherit pkgs;
+    selection = testSelectionRewriteDisabled;
+    name = "agent-skills-test-rewrite-disabled";
   };
 in
 pkgs.runCommand "agent-skills-transform-packages-test" {} ''
@@ -225,6 +275,40 @@ pkgs.runCommand "agent-skills-transform-packages-test" {} ''
   ''}
 
   echo "Case 5 passed!"
+
+  echo ""
+  echo "=== Case 6: rewriteCommands = true (default) ==="
+  skillMd6="${testBundleRewrite}/test-skill-rewrite/SKILL.md"
+
+  test -f "$skillMd6" || { echo "SKILL.md not found"; exit 1; }
+
+  # Bare "jq " should be rewritten to "./jq "
+  grep -q '\./jq ' "$skillMd6" || { echo "jq not rewritten to ./jq"; exit 1; }
+
+  # "| jq " should become "| ./jq "
+  grep -q '| \./jq ' "$skillMd6" || { echo "piped jq not rewritten"; exit 1; }
+
+  # Already-prefixed "./jq" should NOT become "././jq"
+  ! grep -q '\./\./jq' "$skillMd6" || { echo "Double-prefixed ././jq found"; exit 1; }
+
+  # Original bare "jq " at start of line should not remain
+  ! grep -q '^jq ' "$skillMd6" || { echo "Bare jq still present at start of line"; exit 1; }
+
+  echo "Case 6 passed!"
+
+  echo ""
+  echo "=== Case 7: rewriteCommands = false ==="
+  skillMd7="${testBundleRewriteDisabled}/test-skill-rewrite-disabled/SKILL.md"
+
+  test -f "$skillMd7" || { echo "SKILL.md not found"; exit 1; }
+
+  # Bare "jq " should remain (not rewritten)
+  grep -q '^jq ' "$skillMd7" || { echo "Bare jq should remain when rewriteCommands=false"; exit 1; }
+
+  # Dependencies table should still be present
+  grep -q "## Dependencies" "$skillMd7" || { echo "Dependencies section not found"; exit 1; }
+
+  echo "Case 7 passed!"
 
   echo ""
   echo "All tests passed!"

--- a/test/transform-packages.nix
+++ b/test/transform-packages.nix
@@ -121,6 +121,20 @@ ${original}
     };
   };
 
+  # Case 8: multi-binary packages are not rewritten to missing ./binary paths
+  testSelectionRewriteMultiBin = agentLib.selectSkills {
+    catalog = rewriteCatalog;
+    allowlist = [];
+    sources = rewriteSources;
+    skills = {
+      test-skill-rewrite-multi-bin = {
+        from = "rewrite-fixtures";
+        path = ".";
+        packages = [ pkgs.bun ];
+      };
+    };
+  };
+
   # Case 5: Error case - transform is not a function
   invalidSelection = agentLib.selectSkills {
     catalog = testCatalog;
@@ -171,6 +185,12 @@ ${original}
     inherit pkgs;
     selection = testSelectionRewriteDisabled;
     name = "agent-skills-test-rewrite-disabled";
+  };
+
+  testBundleRewriteMultiBin = agentLib.mkBundle {
+    inherit pkgs;
+    selection = testSelectionRewriteMultiBin;
+    name = "agent-skills-test-rewrite-multi-bin";
   };
 in
 pkgs.runCommand "agent-skills-transform-packages-test" {} ''
@@ -309,6 +329,24 @@ pkgs.runCommand "agent-skills-transform-packages-test" {} ''
   grep -q "## Dependencies" "$skillMd7" || { echo "Dependencies section not found"; exit 1; }
 
   echo "Case 7 passed!"
+
+  echo ""
+  echo "=== Case 8: rewriteCommands skips multi-binary packages ==="
+  skillMd8="${testBundleRewriteMultiBin}/test-skill-rewrite-multi-bin/SKILL.md"
+  skillDir8="${testBundleRewriteMultiBin}/test-skill-rewrite-multi-bin"
+
+  test -f "$skillMd8" || { echo "SKILL.md not found"; exit 1; }
+
+  # bun exposes multiple binaries under ./bun/, so bare bunx must not become a missing ./bunx path.
+  grep -q '^bunx --version' "$skillMd8" || { echo "Bare bunx should remain for multi-binary package"; exit 1; }
+  ! grep -q '\./bunx' "$skillMd8" || { echo "bunx was rewritten to missing ./bunx path"; exit 1; }
+
+  # The actual multi-binary package layout should still be available.
+  test -L "$skillDir8/bun" || { echo "bun symlink not found"; exit 1; }
+  test -x "$skillDir8/bun/bun" || { echo "bun binary not found"; exit 1; }
+  test -x "$skillDir8/bun/bunx" || { echo "bunx binary not found"; exit 1; }
+
+  echo "Case 8 passed!"
 
   echo ""
   echo "All tests passed!"


### PR DESCRIPTION
## Summary

- Add `rewriteCommands` boolean option (default: `true`) to `skillType` that automatically rewrites bare package binary names to `./name` paths in SKILL.md content
- Previously, users had to write verbose `transform` functions just to replace command names — this automates that common pattern
- The rewrite is applied before any user-supplied `transform`, so `original` in transform already has rewritten paths
- Double-prefixing (`././name`) is handled correctly

## Example

```nix
# Before: needed a transform function
skills.explicit.ast-grep = {
  from = "ast-grep";
  packages = [ pkgs.ast-grep ];
  transform = { original, dependencies }:
    let
      patched = builtins.replaceStrings
        [ "ast-grep scan " "ast-grep run " ]
        [ "./ast-grep scan " "./ast-grep run " ]
        original;
    in "${patched}\n${dependencies}";
};

# After: automatic (rewriteCommands defaults to true)
skills.explicit.ast-grep = {
  from = "ast-grep";
  packages = [ pkgs.ast-grep ];
};
```

## Test plan

- [x] Case 6: `rewriteCommands = true` — verifies bare command names are rewritten to `./name`
- [x] Case 7: `rewriteCommands = false` — verifies bare names are preserved
- [x] Double-prefix prevention (`././name` → `./name`)
- [x] All existing tests (Cases 1-5) still pass
- [x] `nix flake check` passes