### PR TITLE
Add OpenCode as a built-in install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ skills.enable = [ "openai/pdf" "anthropic/pdf" ];
 |--------|-------------|------------|
 | agents | `$HOME/.agents/skills` | `.agents/skills` |
 | codex | `${CODEX_HOME:-$HOME/.codex}/skills` | `.codex/skills` |
+| opencode | `$HOME/.config/opencode/skills` | `.opencode/skills` |
 | claude | `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills` | `.claude/skills` |
 | copilot | `$HOME/.copilot/skills` | `.github/skills` |
 | cursor | `$HOME/.cursor/skills` | `.cursor/skills` |

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -341,6 +341,12 @@ SKILL_EOF
       enable = false;
       systems = [];
     };
+    opencode = {
+      dest = "$HOME/.config/opencode/skills";
+      structure = "symlink-tree";
+      enable = false;
+      systems = [];
+    };
     claude = {
       dest = "\${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills";
       structure = "symlink-tree";
@@ -385,6 +391,7 @@ SKILL_EOF
   defaultLocalTargets = {
     agents = { dest = ".agents/skills"; structure = "copy-tree"; enable = false; systems = []; };
     codex = { dest = ".codex/skills"; structure = "copy-tree"; enable = false; systems = []; };
+    opencode = { dest = ".opencode/skills"; structure = "copy-tree"; enable = false; systems = []; };
     claude = { dest = ".claude/skills"; structure = "copy-tree"; enable = false; systems = []; };
     copilot = { dest = ".github/skills"; structure = "copy-tree"; enable = false; systems = []; };
     cursor = { dest = ".cursor/skills"; structure = "copy-tree"; enable = false; systems = []; };

--- a/test/targets.nix
+++ b/test/targets.nix
@@ -6,13 +6,13 @@ pkgs.runCommand "agent-skills-targets-test" {} ''
 
   echo "=== Testing targetsFor with default targets ==="
 
-  # Test that default targets include agents, codex, claude, copilot, antigravity, gemini, cursor, and windsurf
+  # Test that default targets include agents, codex, opencode, claude, copilot, antigravity, gemini, cursor, and windsurf
   ${pkgs.lib.concatMapStringsSep "\n" (name: ''
     echo "Checking default target: ${name}"
     test "${agentLib.defaultTargets.${name}.dest}" != "" || { echo "Missing dest for ${name}"; exit 1; }
     test "${agentLib.defaultTargets.${name}.structure}" = "symlink-tree" || { echo "Wrong structure for ${name}"; exit 1; }
     test "${if agentLib.defaultTargets.${name}.enable then "true" else "false"}" = "false" || { echo "Expected ${name}.enable=false by default"; exit 1; }
-  '') ["agents" "codex" "claude" "copilot" "antigravity" "gemini" "cursor" "windsurf"]}
+  '') ["agents" "codex" "opencode" "claude" "copilot" "antigravity" "gemini" "cursor" "windsurf"]}
 
   echo ""
   echo "=== Testing default local targets ==="
@@ -22,7 +22,7 @@ pkgs.runCommand "agent-skills-targets-test" {} ''
     test "${agentLib.defaultLocalTargets.${name}.dest}" != "" || { echo "Missing local dest for ${name}"; exit 1; }
     test "${agentLib.defaultLocalTargets.${name}.structure}" = "copy-tree" || { echo "Wrong local structure for ${name}"; exit 1; }
     test "${if agentLib.defaultLocalTargets.${name}.enable then "true" else "false"}" = "false" || { echo "Expected local ${name}.enable=false by default"; exit 1; }
-  '') ["agents" "codex" "claude" "copilot" "antigravity" "gemini" "cursor" "windsurf"]}
+  '') ["agents" "codex" "opencode" "claude" "copilot" "antigravity" "gemini" "cursor" "windsurf"]}
 
   echo ""
   echo "=== Testing targetsFor filtering ==="


### PR DESCRIPTION
### Motivation
- Add first-class support for OpenCode by providing a named install target so users can easily install skills into the OpenCode skills directory.
- Keep existing behavior unchanged by making the new target opt-in (`enable = false`) and matching the layout semantics used by other targets.

### Description
- Add `opencode` to `defaultTargets` in `lib/default.nix` with global destination set to `$HOME/.config/opencode/skills` and `structure = "symlink-tree"`.
- Add `opencode` to `defaultLocalTargets` in `lib/default.nix` with local destination `.opencode/skills` and `structure = "copy-tree"`.
- Document the new target in the `README.md` default target paths table by inserting an `opencode` row.
- Extend `test/targets.nix` to include `opencode` in the lists of expected default global and local targets.

### Testing
- Updated unit/integration-style assertions in `test/targets.nix` to include `opencode`, but the test suite was not executed in this environment.
- Attempted to run a flake check (`nix flake show --all-systems --json | jq -r '.checks["x86_64-linux"] | keys[]'`) but it failed because `nix` is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c09e8de08321b70b5db9bfa8109c)