### PR TITLE
perf(mkBundle): dump each unique source root once, not 2x per skill

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -347,22 +347,35 @@ let
           chmod -R u+w "$out"
           ${pkgs.findutils}/bin/find "$out" -xtype l -delete
         '';
+      # Dump every unique source root to the store exactly once up front.
+      # builtins.path re-streams its input to the daemon on every call (there
+      # is no eval-time dedup for store-path inputs with a custom name), so
+      # calling sourceRootStorePath per skill multiplied eval-time I/O by 2x
+      # the skill count — e.g. a 68MB root with 32 skills pushed ~4.3GB
+      # through the daemon socket per evaluation.
+      uniqueSourceRoots = unique (map sourceRootFor skills);
+      dumpedRoots = map (root: builtins.path {
+        path = root;
+        name = "agent-skills-source";
+      }) uniqueSourceRoots;
+      # Look up a skill's dumped root by list position: path values compare
+      # by path string under ==, and unlike toString this works on paths that
+      # still carry derivation string context.
+      storePathFor = skill:
+        let i = lib.lists.findFirstIndex (root: root == sourceRootFor skill) null uniqueSourceRoots;
+        in if i == null then throw "agent-skills: internal error: source root not memoized" else builtins.elemAt dumpedRoots i;
       safeSourceRoots = foldl'
-        (acc: skill:
-          let
-            storePath = sourceRootStorePath skill;
-            key = sourceRootKey storePath;
-          in
-          if acc ? ${key} then acc
-          else acc // { ${key} = mkSafeSourceRoot storePath key; })
+        (acc: storePath:
+          let key = sourceRootKey storePath;
+          in acc // { ${key} = mkSafeSourceRoot storePath key; })
         {}
-        skills;
+        dumpedRoots;
       buildCommands = concatMapStringsSep "\n" (skill:
         let
           hasTransform = skill ? transform && skill.transform != null && isFunction skill.transform;
           hasPackages = (skill.packages or []) != [];
           needsCustomisation = hasTransform || hasPackages;
-          safeRoot = safeSourceRoots.${sourceRootKey (sourceRootStorePath skill)};
+          safeRoot = safeSourceRoots.${sourceRootKey (storePathFor skill)};
           sourceRelPath = sourceRelPathFor skill;
           skillPath = appendRelPath safeRoot sourceRelPath;
           validateSkillPath = ''


### PR DESCRIPTION
## Problem

`builtins.path` re-streams its input to the nix daemon on **every call** — there is no eval-time dedup for store-path inputs with a custom `name`. In `mkBundle`:

1. the `safeSourceRoots` fold called `sourceRootStorePath skill` per skill, and
2. `buildCommands` called `sourceRootStorePath skill` again per skill,

so each source root was dumped to the daemon **2 × skill-count** times per evaluation. Every selected skill in a source shares the same `sourceRoot`, so this is pure redundant work.

Measured on a real config (32 skills sharing a 68MB source root): **64 × 68MB ≈ 4.3GB of NAR streaming per eval**, ~70s of a 92s `darwin-rebuild` evaluation on an M2 Ultra (75% of eval time was inside `RemoteStore::addToStoreFromDump`).

## Fix

Hoist the dump: `builtins.path` is mapped over the **unique** source roots once; a skill's dumped root is looked up by list position.

The lookup uses `==` on path values rather than keying by `toString root`, because roots produced from derivations carry string context (`toString` throws "not allowed to refer to a store path"), while `==` compares path values fine.

## Compatibility

No produced store paths change: identical `builtins.path` arguments yield identical dumped paths, so `safeSourceRoots` and the bundle derivations are bit-identical. `sourceRootStorePath` is kept (still used elsewhere).

Eval time on the affected config: **92s → ~19s**.