### PR TITLE
fix: update Antigravity local skills path

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ skills.enable = [ "openai/pdf" "anthropic/pdf" ];
 | copilot | `$HOME/.copilot/skills` | `.github/skills` |
 | cursor | `$HOME/.cursor/skills` | `.cursor/skills` |
 | windsurf | `$HOME/.codeium/windsurf/skills` | `.windsurf/skills` |
-| antigravity | `$HOME/.gemini/antigravity/skills` | `.agent/skills` |
+| antigravity | `$HOME/.gemini/antigravity/skills` | `.agents/skills` |
 | gemini | `$HOME/.gemini/skills` | `.gemini/skills` |
 | pi | `$HOME/.pi/agent/skills` | `.pi/skills` |
 

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -512,7 +512,7 @@ SKILL_EOF
     copilot = { dest = ".github/skills"; structure = "copy-tree"; enable = false; systems = []; };
     cursor = { dest = ".cursor/skills"; structure = "copy-tree"; enable = false; systems = []; };
     windsurf = { dest = ".windsurf/skills"; structure = "copy-tree"; enable = false; systems = []; };
-    antigravity = { dest = ".agent/skills"; structure = "copy-tree"; enable = false; systems = []; };
+    antigravity = { dest = ".agents/skills"; structure = "copy-tree"; enable = false; systems = []; };
     gemini = { dest = ".gemini/skills"; structure = "copy-tree"; enable = false; systems = []; };
     pi = { dest = ".pi/skills"; structure = "copy-tree"; enable = false; systems = []; };
   };

--- a/test/targets.nix
+++ b/test/targets.nix
@@ -24,6 +24,11 @@ pkgs.runCommand "agent-skills-targets-test" {} ''
     test "${if agentLib.defaultLocalTargets.${name}.enable then "true" else "false"}" = "false" || { echo "Expected local ${name}.enable=false by default"; exit 1; }
   '') ["agents" "codex" "opencode" "claude" "copilot" "antigravity" "gemini" "cursor" "windsurf" "pi"]}
 
+  test "${agentLib.defaultLocalTargets.antigravity.dest}" = ".agents/skills" || {
+    echo "Unexpected default local antigravity.dest"
+    exit 1
+  }
+
   echo ""
   echo "=== Testing targetsFor filtering ==="
 


### PR DESCRIPTION
## Summary

- change the Antigravity project-local target from `.agent/skills` to `.agents/skills`
- update the documented target path
- add a regression assertion for the Antigravity local destination

## Why

Antigravity originally used `.agent/skills`, which was the path configured when support was added. Its current documentation now defaults workspace skills to `.agents/skills`, while retaining legacy-path compatibility on the Antigravity side. The repository default had not followed that upstream change.

Project-local Antigravity installs will now write to the documented `.agents/skills` location shared by standard Agent Skills consumers.

## Validation

- `git diff --check`
- `nix flake check --print-build-logs`

Closes #49