### PR TITLE
refactor: extract shared skill sync runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Declarative management of Agent Skills (directories containing `SKILL.md`) with 
 - **sources**: Named inputs (flake or path) pointing at a skills root (`subdir`). Optional `idPrefix` namespaces discovered skill IDs to avoid collisions across sources.
 - **discover**: Recursively scans sources for directories that contain `SKILL.md`, producing a catalog. Skills can be nested (e.g. `ecosystem/c-ecosystem/`) and their IDs use `/` as separator.
 - **skills.enable / skills.enableAll / skills.explicit**: Declaratively pick discovered skills, enable-all (global or by source list), and explicitly specified ones; no accidental auto-install unless you opt in.
-- **targets**: Agent-specific destinations synced from a store bundle (structure: `link`, `symlink-tree`, `copy-tree`). Targets are opt-in (`enable = false` by default). The `dest` option supports shell variable expansion at runtime (e.g. `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills`). See **Default target paths** below.
+- **targets**: Agent-specific destinations synced from a store bundle (structure: `link`, `symlink-tree`, `copy-tree`). Targets are opt-in (`enable = false` by default). Runtime destinations support `$HOME`, `~`, and `${VAR:-$HOME/...}` fallback forms without general shell evaluation. See **Default target paths** below.
 
 ## Source filters
 
@@ -68,7 +68,7 @@ Notes:
 - To enable a default target, set `targets.<name>.enable = true;` (e.g. `targets.claude.enable = true;`).
 - `structure = "link"` uses `home.file` symlinks; `symlink-tree` and `copy-tree` run in `home.activation`.
 - `symlink-tree` uses `rsync -a --delete` (preserve symlinks); `copy-tree` uses `rsync -aL --delete` (dereference symlinks).
-- `dest` supports shell variable expansion at runtime (e.g. `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills`). Note: `link` structure does not support shell variables and will use the fallback path.
+- Runtime `dest` values support `$HOME`, `~`, and `${VAR:-$HOME/...}` fallback forms (e.g. `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills`). Home Manager's `link` structure requires a static path and uses the fallback path.
 - Symlinks inside skills are preserved when their target stays inside the source root; escaping or dangling ones are dropped. See [Symlinks inside skills](#symlinks-inside-skills).
 
 ## Flake outputs
@@ -79,13 +79,15 @@ Notes:
 - `apps.<system>.skills-list`: JSON view of the default catalog.
 - `checks.<system>.skills`: Sanity check that the bundle builds.
 - `homeManagerModules.default`: Home Manager module implementing the DSL above.
-- `lib.agent-skills`: Helper functions (`discoverCatalog`, `selectSkills`, `mkBundle`, `mkLocalInstallScript`, `mkShellHook`, `catalogJson`, `defaultConfig`).
+- `lib.agent-skills`: Helper functions (`discoverCatalog`, `selectSkills`, `mkBundle`, `mkSyncProgram`, `mkLocalInstallProgram`, compatibility wrappers `mkSyncScript` / `mkLocalInstallScript`, `mkShellHook`, `catalogJson`, `defaultConfig`).
 
 ## Library functions
 
 See [`examples/library-functions/snippet.nix`](./examples/library-functions/snippet.nix).
 
 `discoverCatalog` recursively discovers `SKILL.md` directories and generates `/`-separated IDs for nested skills (e.g. `cat-a/skill-1`). Set `idPrefix` on a source to namespace discovered IDs (for example, `openai/pdf`). It enforces `SKILL.md` presence and rejects duplicate IDs after prefixing (error messages include absolute paths for both conflicting sources). `selectSkills` errors on unknown allowlist entries or missing files, preventing accidental drift. (Home Manager maps `skills.enable` → `allowlist` and `skills.explicit` → `skills`.)
+
+`mkSyncProgram` returns a `skills-install` executable after filtering enabled targets for the requested system. `mkLocalInstallProgram` is its project-local wrapper and returns `skills-install-local`. Both serialize a versioned JSON configuration and invoke the shared synchronization runtime; they do not return inline shell source. Existing consumer flakes can continue using `mkSyncScript` and `mkLocalInstallScript`; these compatibility wrappers preserve their original return types while delegating to the shared runtime. `mkShellHook` runs the local program from a development shell.
 
 ## Skill customisation
 
@@ -126,14 +128,14 @@ Package binaries are referenced with local paths (`./jq` or `./pkg/` for multi-b
 - Sync bundle to current directory: `nix run .#skills-install-local`
 
 Local skills are installed to enabled local targets in **Default target paths** relative to the current working directory (or `AGENT_SKILLS_ROOT` if set). Override destinations via `AGENT_SKILLS_LOCAL_DESTS`.
-Targets respect `enable`, `systems`, and `structure` (default `copy-tree`). To exclude a target, disable it or provide custom targets to `mkLocalInstallScript`.
-Local install skips non-Nix-managed existing paths to avoid clobbering user data; set `AGENT_SKILLS_FORCE=1` to overwrite.
+Targets respect `enable`, `systems`, and `structure` (default `copy-tree`). To exclude a target, disable it or provide custom targets to `mkLocalInstallProgram`.
+The synchronizer refuses to replace a non-empty, unmarked directory. A successful tree sync records ownership in `.agent-skills-managed.json`; set `AGENT_SKILLS_FORCE=1` only when you intentionally want agent-skills to take over an existing destination.
 
 Both apps operate on the flake's default (empty) config; point at your own flake/module for real catalogs.
 
 ## Local skills in your project
 
-To install skills locally in your project, use `mkLocalInstallScript` in your flake:
+To install skills locally in your project, use `mkLocalInstallProgram` in your flake:
 
 See [`examples/local-install/flake.nix`](./examples/local-install/flake.nix).
 
@@ -164,9 +166,15 @@ Symlinks inside skill directories are kept when their textual target stays insid
 - Preserves symlinks that stay inside a declared source root and drops escaping or dangling symlinks when materializing bundles.
 - Rejects `..` traversal in source `subdir` and explicit skill `path` values.
 - Caps recursion at 100 levels when maxDepth is null to guard against symlink loops.
-- Activation scripts always `mkdir -p` and use `rsync -a --delete` by default.
+- Passes destinations as JSON data; shell metacharacters and command-substitution syntax are not evaluated as shell code.
+- Tree synchronization validates destination ownership before using `rsync --delete`; managed destinations carry a `.agent-skills-managed.json` marker.
+- Local destinations are resolved beneath `AGENT_SKILLS_ROOT` (or the current directory) and paths that escape that root are rejected.
 
 ## Breaking changes
+
+### Managed destination ownership
+
+Tree synchronization now requires a valid `.agent-skills-managed.json` marker before replacing a non-empty destination. For an existing destination created by an older release, inspect it first and set `AGENT_SKILLS_FORCE=1` for the one-time takeover.
 
 ### filter.maxDepth default changed from 1 to null
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,5 +5,5 @@ Use-case-oriented examples for `agent-skills-nix`.
 - `quickstart/`: two patterns (`main` tightly coupled, `child` separated skills catalog)
 - `library-functions/`: direct use of library helpers
 - `skill-customization/`: `transform` and `packages` customization
-- `local-install/`: project-local install app with `mkLocalInstallScript`
+- `local-install/`: project-local install app with `mkLocalInstallProgram`
 - `devshell/`: auto-install with `mkShellHook`

--- a/examples/local-install/flake.nix
+++ b/examples/local-install/flake.nix
@@ -35,7 +35,7 @@
     {
       apps.${system}.skills-install-local = {
         type = "app";
-        program = "${agentLib.mkLocalInstallScript { inherit pkgs bundle; targets = localTargets; }}/bin/skills-install-local";
+        program = "${agentLib.mkLocalInstallProgram { inherit pkgs bundle; targets = localTargets; }}/bin/skills-install-local";
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -76,15 +76,11 @@
           bundle = bundleFor system;
           listJson = pkgs.writeText "agent-skills-catalog.json" (builtins.toJSON (lib.catalogJson defaultCatalog));
 
-          installScript = pkgs.writeShellApplication {
-            name = "skills-install";
-            runtimeInputs = [ pkgs.rsync pkgs.coreutils ];
-            text = lib.mkSyncScript {
-              inherit pkgs bundle;
-              targets = defaultTargets;
-              system = pkgs.stdenv.hostPlatform.system;
-              allowOverrides = true;
-            };
+          installProgram = lib.mkSyncProgram {
+            inherit pkgs bundle;
+            targets = defaultTargets;
+            system = pkgs.stdenv.hostPlatform.system;
+            allowOverrides = true;
           };
 
           listScript = pkgs.writeShellApplication {
@@ -95,18 +91,18 @@
             '';
           };
 
-          installLocalScript = lib.mkLocalInstallScript {
+          installLocalProgram = lib.mkLocalInstallProgram {
             inherit pkgs bundle;
             targets = defaultLocalTargets;
           };
         in {
           skills-install = {
             type = "app";
-            program = "${installScript}/bin/skills-install";
+            program = "${installProgram}/bin/skills-install";
           };
           skills-install-local = {
             type = "app";
-            program = "${installLocalScript}/bin/skills-install-local";
+            program = "${installLocalProgram}/bin/skills-install-local";
           };
           skills-list = {
             type = "app";

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -44,19 +44,6 @@ let
       throw "agent-skills: ${ctx} '${rel}' must be relative and must not traverse outside the source root"
     else rel;
 
-  # Shared bash helper injected into both the local-install and sync scripts.
-  # Some destinations are populated by previous `copy-tree` runs that copied
-  # from the read-only Nix store, leaving the tree non-writable. rsync needs
-  # write permission to update those trees, so chmod before syncing.
-  ensureWritableTreeBash = ''
-    ensure_writable_tree() {
-      local path="$1"
-      if [ -e "$path" ] && [ ! -L "$path" ]; then
-        chmod -R u+w "$path"
-      fi
-    }
-  '';
-
   # Resolve the root path for a source, preferring an explicit path and
   # falling back to a flake input name.
   resolveSourceRoot = name: cfg:
@@ -522,252 +509,88 @@ SKILL_EOF
   # The leading "/" ensures only the top-level .system is excluded, not .system dirs inside skills.
   defaultExcludePatterns = [ "/.system" ];
 
-  # Create a local install script for use in consumer flakes.
-  # This allows projects to install skills to their local directory.
-  # Respects target enable/system filters and structure (link/symlink-tree/copy-tree).
-  mkLocalInstallScript = { pkgs, bundle, targets ? defaultLocalTargets, excludePatterns ? defaultExcludePatterns }:
-    let
-      activeTargets = targetsFor { inherit targets; system = pkgs.stdenv.hostPlatform.system; };
-      targetsList = lib.mapAttrsToList (name: t:
-        let
-          structure = t.structure or "copy-tree";
-          dest = t.dest;
-        in
-          ''"${name}|${structure}|${dest}"''
-      ) activeTargets;
-      targetsArray = lib.concatStringsSep "\n  " targetsList;
-      excludeFlags = concatMapStringsSep " " (p: "--exclude='${p}'") excludePatterns;
-    in
-    pkgs.writeShellApplication {
-      name = "skills-install-local";
-      runtimeInputs = [ pkgs.rsync pkgs.coreutils ];
-      text = ''
-        root="''${AGENT_SKILLS_ROOT:-$PWD}"
-        bundle=${bundle}
-        if [ ! -d "$bundle" ]; then
-          echo "agent-skills: bundle not built" >&2
-          exit 1
-        fi
-
-        targets=(
-          ${targetsArray}
-        )
-
-        override=()
-        if [ -n "''${AGENT_SKILLS_LOCAL_DESTS:-}" ]; then
-          read -r -a override <<< "''${AGENT_SKILLS_LOCAL_DESTS:-}"
-        fi
-
-        # Check if path is safe to overwrite for the requested structure.
-        is_safe_to_overwrite() {
-          local path="$1"
-          local structure="$2"
-          if [ ! -e "$path" ]; then
-            return 0  # Doesn't exist, safe
-          fi
-          if [ -L "$path" ]; then
-            local target
-            target="$(readlink -f "$path")"
-            if [[ "$target" == /nix/store/* ]]; then
-              return 0  # Symlink to Nix store, safe
-            fi
-            return 1
-          fi
-
-          case "$structure" in
-            copy-tree)
-              # copy-tree is designed for mutable local directories.
-              if [ -d "$path" ]; then
-                return 0
-              fi
-              ;;
-          esac
-
-          return 1  # Not safe
-        }
-
-        ${ensureWritableTreeBash}
-
-        for i in "''${!targets[@]}"; do
-          IFS="|" read -r name structure dest <<< "''${targets[$i]}"
-          if [ -n "''${override[$i]:-}" ]; then
-            dest="''${override[$i]}"
-          fi
-          if [ -z "$dest" ]; then
-            continue
-          fi
-          full_dest="$root/$dest"
-
-          if ! is_safe_to_overwrite "$full_dest" "$structure"; then
-            echo "agent-skills: $full_dest exists and is not a Nix-managed path" >&2
-            echo "agent-skills: skipping to avoid overwriting user data" >&2
-            echo "agent-skills: remove manually or set AGENT_SKILLS_FORCE=1 to overwrite" >&2
-            if [ "''${AGENT_SKILLS_FORCE:-}" != "1" ]; then
-              continue
-            fi
-            echo "agent-skills: AGENT_SKILLS_FORCE=1 set, overwriting anyway" >&2
-          fi
-
-          case "$structure" in
-            link)
-              mkdir -p "$(dirname "$full_dest")"
-              rm -rf "$full_dest"
-              ln -s "$bundle" "$full_dest"
-              ;;
-            symlink-tree)
-              if [ -L "$full_dest" ]; then
-                rm -rf "$full_dest"
-              fi
-              mkdir -p "$full_dest"
-              ensure_writable_tree "$full_dest"
-              ${pkgs.rsync}/bin/rsync -a --delete ${excludeFlags} "$bundle/" "$full_dest/"
-              # Ensure dest is writable so agents can create subdirectories (e.g., .system)
-              chmod u+w "$full_dest"
-              ;;
-            copy-tree)
-              if [ -L "$full_dest" ]; then
-                rm -rf "$full_dest"
-              fi
-              mkdir -p "$full_dest"
-              ensure_writable_tree "$full_dest"
-              ${pkgs.rsync}/bin/rsync -aL --delete ${excludeFlags} "$bundle/" "$full_dest/"
-              # Ensure dest is writable so agents can create subdirectories (e.g., .system)
-              chmod u+w "$full_dest"
-              ;;
-            *)
-              echo "agent-skills: unknown structure '$structure' for target '$name'" >&2
-              exit 1
-              ;;
-          esac
-
-          echo "agent-skills: installed to $full_dest"
-        done
-
-        if [ "''${#override[@]}" -gt "''${#targets[@]}" ]; then
-          for ((i=''${#targets[@]}; i<''${#override[@]}; i++)); do
-            dest="''${override[$i]}"
-            if [ -z "$dest" ]; then
-              continue
-            fi
-            full_dest="$root/$dest"
-            if ! is_safe_to_overwrite "$full_dest" "copy-tree"; then
-              echo "agent-skills: $full_dest exists and is not a Nix-managed path" >&2
-              echo "agent-skills: skipping to avoid overwriting user data" >&2
-              echo "agent-skills: remove manually or set AGENT_SKILLS_FORCE=1 to overwrite" >&2
-              if [ "''${AGENT_SKILLS_FORCE:-}" != "1" ]; then
-                continue
-              fi
-              echo "agent-skills: AGENT_SKILLS_FORCE=1 set, overwriting anyway" >&2
-            fi
-            if [ -L "$full_dest" ]; then
-              rm -rf "$full_dest"
-            fi
-            mkdir -p "$full_dest"
-            ensure_writable_tree "$full_dest"
-            ${pkgs.rsync}/bin/rsync -aL --delete ${excludeFlags} "$bundle/" "$full_dest/"
-            # Ensure dest is writable so agents can create subdirectories (e.g., .system)
-            chmod u+w "$full_dest"
-            echo "agent-skills: installed to $full_dest"
-          done
-        fi
-      '';
-    };
-
-  # Create a sync script for user-level installation targets.
-  # Respects target enable/system filters and structure (link/symlink-tree/copy-tree).
-  # Optionally allows overriding destinations via an environment variable.
-  mkSyncScript = {
+  # Build an executable that delegates synchronization to the shared runtime.
+  # Nix is responsible only for filtering targets and serializing configuration;
+  # destination expansion and filesystem safety checks happen at runtime.
+  mkSyncProgram = {
     pkgs,
     bundle,
     targets,
     system ? pkgs.stdenv.hostPlatform.system,
+    mode ? "global",
+    programName ? (if mode == "local" then "skills-install-local" else "skills-install"),
     allowOverrides ? false,
-    overrideEnvVar ? "AGENT_SKILLS_DESTS",
-    overrideStructure ? "symlink-tree",
+    overrideEnvVar ? (if mode == "local" then "AGENT_SKILLS_LOCAL_DESTS" else "AGENT_SKILLS_DESTS"),
+    overrideStructure ? (if mode == "local" then "copy-tree" else "symlink-tree"),
     excludePatterns ? defaultExcludePatterns,
   }:
     let
       activeTargets = targetsFor { inherit targets system; };
-      targetsList = lib.mapAttrsToList (name: t:
-        let
-          structure = t.structure or "symlink-tree";
-          dest = t.dest;
-        in
-          ''"${name}|${structure}|${dest}"''
-      ) activeTargets;
-      targetsArray = lib.concatStringsSep "\n  " targetsList;
-      excludeFlags = concatMapStringsSep " " (p: "--exclude='${p}'") excludePatterns;
-      overrideVar = "\${" + overrideEnvVar + ":-}";
-      overrideSnippet = if allowOverrides then ''
-        if [ -n "${overrideVar}" ]; then
-          read -r -a override <<< "${overrideVar}"
-          for dest in "''${override[@]}"; do
-            if [ -z "$dest" ]; then continue; fi
-            sync_dest "$dest" "${overrideStructure}" "override"
-          done
-          exit 0
-        fi
-      '' else "";
+      config = {
+        schemaVersion = 1;
+        inherit mode excludePatterns;
+        bundle = "${bundle}";
+        targets = lib.mapAttrsToList (name: target: {
+          inherit name;
+          structure = target.structure or (if mode == "local" then "copy-tree" else "symlink-tree");
+          dest = target.dest;
+        }) activeTargets;
+        overrides = {
+          enabled = allowOverrides;
+          envVar = overrideEnvVar;
+          structure = overrideStructure;
+        };
+      };
+      configFile = pkgs.writeText "${programName}-config.json" (builtins.toJSON config);
+    in
+    pkgs.writeShellApplication {
+      name = programName;
+      runtimeInputs = [
+        pkgs.coreutils
+        pkgs.jq
+        pkgs.rsync
+      ];
+      text = ''
+        exec ${pkgs.bash}/bin/bash ${../scripts/sync.sh} ${configFile} "$@"
+      '';
+    };
+
+  # Project-local synchronization uses the same runtime with local path guards
+  # and the established local override environment variables.
+  mkLocalInstallProgram = {
+    pkgs,
+    bundle,
+    targets ? defaultLocalTargets,
+    system ? pkgs.stdenv.hostPlatform.system,
+    excludePatterns ? defaultExcludePatterns,
+  }:
+    mkSyncProgram {
+      inherit pkgs bundle targets system excludePatterns;
+      mode = "local";
+      programName = "skills-install-local";
+      allowOverrides = true;
+      overrideEnvVar = "AGENT_SKILLS_LOCAL_DESTS";
+      overrideStructure = "copy-tree";
+    };
+
+  # Compatibility wrappers for consumer flakes using the original public API.
+  # New code should use mkSyncProgram/mkLocalInstallProgram directly.
+  mkSyncScript = args:
+    let
+      syncProgram = mkSyncProgram args;
     in ''
-      bundle=${bundle}
-      if [ ! -d "$bundle" ]; then
-        echo "agent-skills: bundle not built" >&2
-        exit 1
-      fi
-
-      ${ensureWritableTreeBash}
-
-      sync_dest() {
-        local dest="$1"
-        local structure="$2"
-        local name="$3"
-        case "$structure" in
-          link)
-            mkdir -p "$(dirname "$dest")"
-            rm -rf "$dest"
-            ln -s "$bundle" "$dest"
-            ;;
-          symlink-tree)
-            mkdir -p "$dest"
-            ensure_writable_tree "$dest"
-            ${pkgs.rsync}/bin/rsync -a --delete ${excludeFlags} "$bundle/" "$dest/"
-            # Ensure dest is writable so agents can create subdirectories (e.g., .system)
-            chmod u+w "$dest"
-            ;;
-          copy-tree)
-            mkdir -p "$dest"
-            ensure_writable_tree "$dest"
-            ${pkgs.rsync}/bin/rsync -aL --delete ${excludeFlags} "$bundle/" "$dest/"
-            # Ensure dest is writable so agents can create subdirectories (e.g., .system)
-            chmod u+w "$dest"
-            ;;
-          *)
-            echo "agent-skills: unknown structure '$structure' for target '$name'" >&2
-            exit 1
-            ;;
-        esac
-      }
-
-      ${overrideSnippet}
-
-      targets=(
-        ${targetsArray}
-      )
-
-      for entry in "''${targets[@]}"; do
-        IFS="|" read -r name structure dest <<< "$entry"
-        if [ -z "$dest" ]; then continue; fi
-        sync_dest "$dest" "$structure" "$name"
-      done
+      ${syncProgram}/bin/skills-install
     '';
+
+  mkLocalInstallScript = args: mkLocalInstallProgram args;
 
   # Create a shellHook string for use in devShells.
   # Automatically installs skills when entering the dev shell.
   mkShellHook = { pkgs, bundle, targets ? defaultLocalTargets, excludePatterns ? defaultExcludePatterns }:
     let
-      installScript = mkLocalInstallScript { inherit pkgs bundle targets excludePatterns; };
+      installProgram = mkLocalInstallProgram { inherit pkgs bundle targets excludePatterns; };
     in ''
-      ${installScript}/bin/skills-install-local
+      ${installProgram}/bin/skills-install-local
     '';
 
 in
@@ -782,7 +605,9 @@ in
   getPkgBinInfo = getPkgBinInfo;
   catalogJson = catalogJson;
   mkLocalInstallScript = mkLocalInstallScript;
+  mkLocalInstallProgram = mkLocalInstallProgram;
   mkSyncScript = mkSyncScript;
+  mkSyncProgram = mkSyncProgram;
   mkShellHook = mkShellHook;
   defaultTargets = defaultTargets;
   defaultLocalTargets = defaultLocalTargets;

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -27,13 +27,14 @@ let
           then agentLib.defaultTargets.${name}.dest
           else throw "agent-skills: target '${name}' requires a 'dest' option";
         description = ''
-          Destination path for skills. Supports shell variable expansion at runtime.
+          Destination path for skills. Global targets support $HOME, ~, and
+          ''${VAR:-$HOME/...} fallback forms at runtime; local paths are literal.
           See README.md#default-target-paths for the full default path matrix.
           Examples:
             - "$HOME/.agents/skills" (global)
             - ".agents/skills" (project-local)
             - "''${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills" (env-expanded)
-          Note: 'link' structure type does not support shell variable expansion;
+          Note: 'link' structure type does not support runtime path expressions;
           use 'symlink-tree' or 'copy-tree' for dynamic paths.
         '';
       };

--- a/modules/home-manager/agent-skills.nix
+++ b/modules/home-manager/agent-skills.nix
@@ -18,7 +18,7 @@ let
   linkTargets = lib.filterAttrs (_: t: t.structure == "link") activeTargets;
   syncTargets = lib.filterAttrs (_: t: t.structure != "link") activeTargets;
 
-  syncScript = bundle: agentLib.mkSyncScript {
+  syncProgram = bundle: agentLib.mkSyncProgram {
     inherit pkgs bundle;
     targets = syncTargets;
     system = pkgs.stdenv.hostPlatform.system;
@@ -36,7 +36,9 @@ in
     ];
 
     home.activation.agent-skills =
-      lib.mkIf (syncTargets != {}) (lib.hm.dag.entryAfter [ "writeBoundary" ] (syncScript bundle));
+      lib.mkIf (syncTargets != {}) (lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        ${syncProgram bundle}/bin/skills-install
+      '');
 
     # Note: 'link' structure type uses home.file which requires a static path relative to $HOME.
     # Shell variable expansion in dest is not supported for 'link' type.

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,0 +1,456 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly PROGRAM_NAME="agent-skills"
+readonly MARKER_NAME=".agent-skills-managed.json"
+
+die() {
+  printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+  exit 1
+}
+
+warn() {
+  printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+is_structure() {
+  case "$1" in
+    link | symlink-tree | copy-tree) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+directory_is_empty() (
+  local path="$1"
+  local entries
+
+  shopt -s nullglob dotglob
+  entries=("$path"/*)
+  [ "${#entries[@]}" -eq 0 ]
+)
+
+is_nix_store_symlink() {
+  local path="$1"
+  local resolved
+
+  [ -L "$path" ] || return 1
+  resolved="$(realpath -- "$path" 2>/dev/null)" || return 1
+  case "$resolved" in
+    /nix/store/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+has_valid_marker() {
+  local path="$1"
+  local marker="$path/$MARKER_NAME"
+
+  [ -f "$marker" ] && [ ! -L "$marker" ] || return 1
+  jq -e '
+    type == "object" and
+    ((keys - ["bundle", "managedBy", "mode", "schemaVersion", "structure", "target"]) | length == 0) and
+    .schemaVersion == 1 and
+    .managedBy == "agent-skills-nix" and
+    (.mode == "local" or .mode == "global") and
+    (.bundle | type == "string" and length > 0) and
+    (.target | type == "string" and length > 0) and
+    (.structure == "symlink-tree" or .structure == "copy-tree")
+  ' "$marker" >/dev/null 2>&1
+}
+
+is_managed_destination() {
+  local path="$1"
+
+  if [ ! -e "$path" ] && [ ! -L "$path" ]; then
+    return 0
+  fi
+  if is_nix_store_symlink "$path"; then
+    return 0
+  fi
+  if [ -L "$path" ]; then
+    return 1
+  fi
+  if [ -d "$path" ] && directory_is_empty "$path"; then
+    return 0
+  fi
+  if [ -d "$path" ] && has_valid_marker "$path"; then
+    return 0
+  fi
+  return 1
+}
+
+ensure_writable_tree() {
+  local path="$1"
+
+  [ -d "$path" ] || return 0
+  chmod -R u+w -- "$path" 2>/dev/null || true
+}
+
+# Canonicalize the parent but deliberately do not dereference the final path.
+# A final symlink into /nix/store is a safe, replaceable managed destination.
+canonical_destination() {
+  local path="$1"
+  local lexical parent leaf resolved_parent
+
+  lexical="$(realpath -m -s -- "$path")" || return 1
+  if [ "$lexical" = "/" ]; then
+    printf '/\n'
+    return 0
+  fi
+  parent="$(dirname -- "$lexical")"
+  leaf="$(basename -- "$lexical")"
+  resolved_parent="$(realpath -m -- "$parent")" || return 1
+  realpath -m -s -- "$resolved_parent/$leaf"
+}
+
+assert_safe_common_destination() {
+  local path="$1"
+  local home_path="" home_resolved=""
+
+  [ "$path" != "/" ] || die "refusing to synchronize to /"
+  if [ -n "${HOME:-}" ]; then
+    home_path="$(canonical_destination "$HOME")" || die "could not normalize HOME"
+    home_resolved="$(realpath -m -- "$HOME")" || die "could not resolve HOME"
+    if [ "$path" = "$home_path" ] || [ "$path" = "$home_resolved" ]; then
+      die "refusing to synchronize to HOME itself: $path"
+    fi
+  fi
+
+  case "$path" in
+    /nix/store | /nix/store/*) die "refusing to synchronize inside /nix/store: $path" ;;
+  esac
+
+  case "$bundle_path/" in
+    "$path/"*) die "destination contains the bundle: $path" ;;
+  esac
+  case "$path/" in
+    "$bundle_path/"*) die "destination is inside the bundle: $path" ;;
+  esac
+}
+
+resolve_local_destination() {
+  local raw="$1"
+  local lexical parent leaf resolved_parent resolved
+
+  [ -n "$raw" ] || die "local destination must not be empty"
+  case "$raw" in
+    /*) die "local destination must be relative: $raw" ;;
+  esac
+
+  lexical="$(realpath -m -s -- "$local_root/$raw")" || die "could not normalize local destination: $raw"
+  [ "$lexical" != "$local_root" ] || die "local destination must not be the project root: $raw"
+  case "$lexical/" in
+    "$local_root/"*) ;;
+    *) die "local destination escapes the project root: $raw" ;;
+  esac
+
+  parent="$(dirname -- "$lexical")"
+  leaf="$(basename -- "$lexical")"
+  resolved_parent="$(realpath -m -- "$parent")" || die "could not resolve local destination parent: $raw"
+  resolved="$(realpath -m -s -- "$resolved_parent/$leaf")" || die "could not resolve local destination: $raw"
+  [ "$resolved" != "$local_root" ] || die "local destination must not be the project root: $raw"
+  case "$resolved/" in
+    "$local_root/"*) ;;
+    *) die "local destination escapes the project root through a symlink: $raw" ;;
+  esac
+
+  assert_safe_common_destination "$resolved"
+  printf '%s\n' "$resolved"
+}
+
+expand_home_path() {
+  local raw="$1"
+
+  [ -n "${HOME:-}" ] || die "HOME is required to expand destination: $raw"
+  case "$raw" in
+    \$HOME) printf '%s\n' "$HOME" ;;
+    \$HOME/*) printf '%s%s\n' "$HOME" "${raw#\$HOME}" ;;
+    *) die "unsupported HOME expression in destination: $raw" ;;
+  esac
+}
+
+expand_global_destination() {
+  local raw="$1"
+  local result="" after_open inside suffix variable fallback variable_value
+
+  [ -n "$raw" ] || die "global destination must not be empty"
+  case "$raw" in
+    \$HOME | \$HOME/*)
+      result="$(expand_home_path "$raw")"
+      ;;
+    \$\{*)
+      after_open="${raw:2}"
+      case "$after_open" in
+        *'}'*) ;;
+        *) die "invalid destination expression: $raw" ;;
+      esac
+      inside="${after_open%%\}*}"
+      suffix="${after_open#*\}}"
+      case "$inside" in
+        *':-'*) ;;
+        *) die "invalid destination fallback expression: $raw" ;;
+      esac
+      variable="${inside%%:-*}"
+      fallback="${inside#*:-}"
+      [[ "$variable" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || die "invalid destination environment variable: $variable"
+      case "$suffix" in
+        '' | /*) ;;
+        *) die "destination suffix must be empty or begin with '/': $raw" ;;
+      esac
+      if variable_value="$(printenv "$variable" 2>/dev/null)" && [ -n "$variable_value" ]; then
+        result="$variable_value$suffix"
+      else
+        result="$(expand_home_path "$fallback")$suffix"
+      fi
+      ;;
+    \~)
+      [ -n "${HOME:-}" ] || die "HOME is required to expand destination: $raw"
+      result="$HOME"
+      ;;
+    \~/*)
+      [ -n "${HOME:-}" ] || die "HOME is required to expand destination: $raw"
+      result="$HOME/${raw#\~/}"
+      ;;
+    *)
+      case "$raw" in
+        *'$'*) die "unsupported variable expression in destination: $raw" ;;
+      esac
+      result="$raw"
+      ;;
+  esac
+
+  case "$result" in
+    *'$'*) die "unexpanded '$' in destination: $raw" ;;
+    /*) ;;
+    *) die "global destination must resolve to an absolute path: $raw" ;;
+  esac
+  canonical_destination "$result" || die "could not resolve global destination: $raw"
+}
+
+write_marker() {
+  local destination="$1"
+  local target_name="$2"
+  local structure="$3"
+  local marker="$destination/$MARKER_NAME"
+  local temporary="$destination/.${MARKER_NAME}.tmp.$$"
+
+  chmod u+w -- "$destination" 2>/dev/null || true
+  jq -n \
+    --arg mode "$mode" \
+    --arg bundle "$bundle_path" \
+    --arg target "$target_name" \
+    --arg structure "$structure" \
+    '{schemaVersion: 1, managedBy: "agent-skills-nix", mode: $mode, bundle: $bundle, target: $target, structure: $structure}' \
+    >"$temporary"
+  mv -f -- "$temporary" "$marker"
+}
+
+check_overwrite_permission() {
+  local destination="$1"
+
+  if is_managed_destination "$destination"; then
+    return 0
+  fi
+  if [ "${AGENT_SKILLS_FORCE:-}" = "1" ]; then
+    warn "$destination is not managed; AGENT_SKILLS_FORCE=1 permits replacement"
+    return 0
+  fi
+  die "$destination exists and is non-empty but has no $MARKER_NAME marker; set AGENT_SKILLS_FORCE=1 to replace it"
+}
+
+prepare_destination() {
+  local raw_destination="$1"
+  local structure="$2"
+  local target_name="$3"
+  local destination
+
+  is_structure "$structure" || die "unknown structure '$structure' for target '$target_name'"
+  if [ "$mode" = "local" ]; then
+    destination="$(resolve_local_destination "$raw_destination")"
+  else
+    destination="$(expand_global_destination "$raw_destination")"
+    assert_safe_common_destination "$destination"
+  fi
+
+  check_overwrite_permission "$destination"
+  printf '%s\n' "$destination"
+}
+
+sync_destination() {
+  local destination="$1"
+  local structure="$2"
+  local target_name="$3"
+  local -a rsync_args
+
+  case "$structure" in
+    link)
+      mkdir -p -- "$(dirname -- "$destination")"
+      if [ -e "$destination" ] || [ -L "$destination" ]; then
+        rm -rf -- "$destination"
+      fi
+      ln -s -- "$bundle_path" "$destination"
+      ;;
+    symlink-tree | copy-tree)
+      if [ -L "$destination" ] || { [ -e "$destination" ] && [ ! -d "$destination" ]; }; then
+        rm -rf -- "$destination"
+      fi
+      mkdir -p -- "$destination"
+      ensure_writable_tree "$destination"
+      # Claim ownership before rsync so an interrupted first synchronization
+      # can be retried without requiring AGENT_SKILLS_FORCE.
+      write_marker "$destination" "$target_name" "$structure"
+      rsync_args=(-a --delete --filter "P /$MARKER_NAME" --exclude "/$MARKER_NAME")
+      if [ "$structure" = "copy-tree" ]; then
+        rsync_args+=(-L)
+      fi
+      while IFS= read -r exclude_pattern; do
+        rsync_args+=(--exclude="$exclude_pattern")
+      done < <(jq -r '.excludePatterns[]' "$config_path")
+      rsync "${rsync_args[@]}" -- "$bundle_path/" "$destination/"
+      chmod u+w -- "$destination"
+      ;;
+  esac
+
+  printf '%s: installed %s to %s\n' "$PROGRAM_NAME" "$target_name" "$destination"
+}
+
+[ "$#" -eq 1 ] || die "usage: sync.sh CONFIG_JSON_PATH"
+config_path="$1"
+[ -f "$config_path" ] || die "configuration file not found: $config_path"
+
+require_command jq
+require_command rsync
+require_command realpath
+require_command dirname
+require_command basename
+require_command printenv
+
+jq -e '
+  def safe_text:
+    type == "string" and (test("[\\x00-\\x1F\\x7F]") | not);
+  def structure:
+    . == "link" or . == "symlink-tree" or . == "copy-tree";
+  type == "object" and
+  ((keys - ["bundle", "excludePatterns", "mode", "overrides", "schemaVersion", "targets"]) | length == 0) and
+  .schemaVersion == 1 and
+  (.mode == "local" or .mode == "global") and
+  (.bundle | safe_text and length > 0) and
+  (.targets | type == "array") and
+  (.targets | all(.[];
+    type == "object" and
+    ((keys - ["dest", "name", "structure"]) | length == 0) and
+    (.name | safe_text and length > 0) and
+    (.dest | safe_text and length > 0) and
+    (.structure | type == "string" and structure)
+  )) and
+  ((.targets | map(.name) | unique | length) == (.targets | length)) and
+  (.excludePatterns | type == "array" and all(.[]; safe_text)) and
+  (.overrides | type == "object") and
+  (.overrides | ((keys - ["enabled", "envVar", "structure"]) | length == 0)) and
+  (.overrides.enabled | type == "boolean") and
+  (.overrides.envVar | safe_text and test("^[A-Za-z_][A-Za-z0-9_]*$")) and
+  (.overrides.structure | type == "string" and structure)
+' "$config_path" >/dev/null || die "invalid configuration in $config_path"
+
+mode="$(jq -r '.mode' "$config_path")"
+bundle="$(jq -r '.bundle' "$config_path")"
+[ -d "$bundle" ] || die "bundle directory not found: $bundle"
+bundle_path="$(realpath -- "$bundle")" || die "could not resolve bundle: $bundle"
+
+local_root=""
+if [ "$mode" = "local" ]; then
+  root_input="${AGENT_SKILLS_ROOT:-$PWD}"
+  [ -d "$root_input" ] || die "local root is not a directory: $root_input"
+  local_root="$(realpath -- "$root_input")" || die "could not resolve local root: $root_input"
+  [ "$local_root" != "/" ] || die "local root must not be /"
+fi
+
+override_enabled="$(jq -r '.overrides.enabled' "$config_path")"
+override_env_var="$(jq -r '.overrides.envVar' "$config_path")"
+override_structure="$(jq -r '.overrides.structure' "$config_path")"
+override_raw=""
+overrides=()
+if [ "$override_enabled" = "true" ]; then
+  override_raw="$(printenv "$override_env_var" 2>/dev/null || true)"
+  if [ -n "$override_raw" ]; then
+    IFS=$' \t\n' read -r -a overrides <<<"$override_raw"
+  fi
+fi
+
+target_names=()
+target_structures=()
+target_destinations=()
+
+if [ "$mode" = "global" ] && [ "${#overrides[@]}" -gt 0 ]; then
+  index=0
+  for destination in "${overrides[@]}"; do
+    target_names+=("override-$index")
+    target_structures+=("$override_structure")
+    target_destinations+=("$destination")
+    index=$((index + 1))
+  done
+else
+  target_count="$(jq '.targets | length' "$config_path")"
+  index=0
+  while [ "$index" -lt "$target_count" ]; do
+    target_name="$(jq -r --argjson index "$index" '.targets[$index].name' "$config_path")"
+    target_structure="$(jq -r --argjson index "$index" '.targets[$index].structure' "$config_path")"
+    target_destination="$(jq -r --argjson index "$index" '.targets[$index].dest' "$config_path")"
+    if [ "$mode" = "local" ] && [ "$index" -lt "${#overrides[@]}" ]; then
+      target_destination="${overrides[$index]}"
+    fi
+    target_names+=("$target_name")
+    target_structures+=("$target_structure")
+    target_destinations+=("$target_destination")
+    index=$((index + 1))
+  done
+
+  if [ "$mode" = "local" ] && [ "${#overrides[@]}" -gt "$target_count" ]; then
+    index="$target_count"
+    while [ "$index" -lt "${#overrides[@]}" ]; do
+      target_names+=("override-$index")
+      target_structures+=("copy-tree")
+      target_destinations+=("${overrides[$index]}")
+      index=$((index + 1))
+    done
+  fi
+fi
+
+# Resolve and authorize every target before changing any destination. Also
+# reject equal or nested destinations, whose --delete operations would race.
+resolved_destinations=()
+index=0
+while [ "$index" -lt "${#target_names[@]}" ]; do
+  destination="$(prepare_destination \
+    "${target_destinations[$index]}" \
+    "${target_structures[$index]}" \
+    "${target_names[$index]}")"
+  for existing_destination in "${resolved_destinations[@]}"; do
+    case "$destination/" in
+      "$existing_destination/"*)
+        die "destinations overlap: $existing_destination and $destination"
+        ;;
+    esac
+    case "$existing_destination/" in
+      "$destination/"*)
+        die "destinations overlap: $destination and $existing_destination"
+        ;;
+    esac
+  done
+  resolved_destinations+=("$destination")
+  index=$((index + 1))
+done
+
+index=0
+while [ "$index" -lt "${#target_names[@]}" ]; do
+  sync_destination \
+    "${resolved_destinations[$index]}" \
+    "${target_structures[$index]}" \
+    "${target_names[$index]}"
+  index=$((index + 1))
+done

--- a/test/compatibility.nix
+++ b/test/compatibility.nix
@@ -1,0 +1,44 @@
+# Verify that existing consumer flakes can keep using the original helper API.
+{ pkgs, agentLib, bundle }:
+
+let
+  legacyLocalProgram = agentLib.mkLocalInstallScript {
+    inherit pkgs bundle;
+    targets = {};
+  };
+
+  currentLocalProgram = agentLib.mkLocalInstallProgram {
+    inherit pkgs bundle;
+    targets = {};
+  };
+
+  legacySyncText = agentLib.mkSyncScript {
+    inherit pkgs bundle;
+    targets = {};
+  };
+
+  legacyWrappedProgram = pkgs.writeShellApplication {
+    name = "legacy-skills-install";
+    text = legacySyncText;
+  };
+
+  _assertLocalDerivation =
+    if pkgs.lib.isDerivation legacyLocalProgram then true
+    else throw "agent-skills compatibility test failed: mkLocalInstallScript must return a derivation";
+
+  _assertLocalAlias =
+    if legacyLocalProgram.outPath == currentLocalProgram.outPath then true
+    else throw "agent-skills compatibility test failed: legacy local helper must delegate to the current program";
+
+  _assertSyncText =
+    if builtins.isString legacySyncText && pkgs.lib.hasInfix "/bin/skills-install" legacySyncText then true
+    else throw "agent-skills compatibility test failed: mkSyncScript must return runnable shell source";
+in
+assert _assertLocalDerivation;
+assert _assertLocalAlias;
+assert _assertSyncText;
+pkgs.runCommand "agent-skills-consumer-api-compatibility-test" {} ''
+  ${legacyLocalProgram}/bin/skills-install-local
+  ${legacyWrappedProgram}/bin/legacy-skills-install
+  mkdir -p "$out"
+''

--- a/test/default.nix
+++ b/test/default.nix
@@ -29,6 +29,17 @@
     inherit pkgs agentLib;
   };
 
+  sync-shellcheck = pkgs.runCommand "agent-skills-sync-shellcheck" {
+    nativeBuildInputs = [ pkgs.shellcheck ];
+  } ''
+    shellcheck ${../scripts/sync.sh}
+    mkdir -p "$out"
+  '';
+
+  compatibility = import ./compatibility.nix {
+    inherit pkgs agentLib bundle;
+  };
+
   home-manager-warnings = import ./home-manager-warnings.nix {
     inherit pkgs hmLib agentSkillsModule;
   };

--- a/test/home-manager-input-source.nix
+++ b/test/home-manager-input-source.nix
@@ -43,8 +43,8 @@ let
     else throw "agent-skills input-source test failed: expected skill catalog entry from input source";
 
   _assertActivation =
-    if pkgs.lib.hasInfix "bundle=/nix/store/" activation then true
-    else throw "agent-skills input-source test failed: activation script did not capture the bundle path";
+    if pkgs.lib.hasInfix "/bin/skills-install" activation then true
+    else throw "agent-skills input-source test failed: activation script did not invoke the sync program";
 in
 assert _assertBundle;
 assert _assertCatalog;

--- a/test/local-install-script.nix
+++ b/test/local-install-script.nix
@@ -1,7 +1,10 @@
-# Test mkLocalInstallScript behavior around copy-tree overwrite safety.
+# Integration tests for safe local and global synchronization programs.
 { pkgs, agentLib }:
 
 let
+  markerName = ".agent-skills-managed.json";
+  specialDest = "special dir/quote'\"/$(touch PWNED)/skills";
+
   testSources = {
     test-skill = {
       path = ./fixtures/test-skill;
@@ -23,11 +26,13 @@ let
   testBundle = agentLib.mkBundle {
     inherit pkgs;
     selection = testSelection;
-    name = "agent-skills-test-local-install-bundle";
+    name = "agent-skills-test-sync-bundle";
   };
-  installScript = agentLib.mkLocalInstallScript {
+
+  copyProgram = agentLib.mkLocalInstallProgram {
     inherit pkgs;
     bundle = testBundle;
+    excludePatterns = [ "/.system" "/keep-me" ];
     targets = {
       codex = {
         dest = ".codex/skills";
@@ -37,89 +42,358 @@ let
       };
     };
   };
-  syncScript = pkgs.writeShellApplication {
-    name = "skills-sync-test";
-    runtimeInputs = [
-      pkgs.rsync
-      pkgs.coreutils
-    ];
-    text = agentLib.mkSyncScript {
-      inherit pkgs;
-      bundle = testBundle;
-      targets = {
-        codex = {
-          dest = "$PWD/sync/skills";
-          structure = "symlink-tree";
-          enable = true;
-          systems = [ ];
-        };
+
+  specialDestProgram = agentLib.mkLocalInstallProgram {
+    inherit pkgs;
+    bundle = testBundle;
+    targets = {
+      special = {
+        dest = specialDest;
+        structure = "copy-tree";
+        enable = true;
+        systems = [ ];
       };
-      system = pkgs.stdenv.hostPlatform.system;
+    };
+  };
+
+  preflightProgram = agentLib.mkLocalInstallProgram {
+    inherit pkgs;
+    bundle = testBundle;
+    targets = {
+      first = {
+        dest = "first/skills";
+        structure = "copy-tree";
+        enable = true;
+        systems = [ ];
+      };
+      second = {
+        dest = "second/skills";
+        structure = "copy-tree";
+        enable = true;
+        systems = [ ];
+      };
+    };
+  };
+
+  linkProgram = agentLib.mkLocalInstallProgram {
+    inherit pkgs;
+    bundle = testBundle;
+    targets = {
+      bundle = {
+        dest = "linked-bundle";
+        structure = "link";
+        enable = true;
+        systems = [ ];
+      };
+    };
+  };
+
+  symlinkProgram = agentLib.mkSyncProgram {
+    inherit pkgs;
+    bundle = testBundle;
+    programName = "skills-sync-test";
+    allowOverrides = true;
+    excludePatterns = [ "/.system" "/keep-me" ];
+    targets = {
+      codex = {
+        dest = "\${AGENT_SKILLS_TEST_HOME:-$HOME/sync}/skills";
+        structure = "symlink-tree";
+        enable = true;
+        systems = [ ];
+      };
     };
   };
 in
-pkgs.runCommand "agent-skills-local-install-script-test" { } ''
+pkgs.runCommand "agent-skills-sync-program-integration-test" { } ''
   set -euo pipefail
 
-  # should install copy-tree into a pre-existing destination directory
-  project="$PWD/project"
-  mkdir -p "$project/.codex/skills"
-  echo "sentinel" > "$project/.codex/skills/EXISTING.txt"
+  fail() {
+    echo "ERROR: $*" >&2
+    exit 1
+  }
+
+  # The static runtime rejects unknown config schema versions before touching
+  # any destination.
+  invalid_config="$PWD/invalid-config.json"
+  printf '{"schemaVersion":2}\n' > "$invalid_config"
+  if PATH=${pkgs.lib.makeBinPath [ pkgs.coreutils pkgs.jq pkgs.rsync ]} \
+    ${pkgs.bash}/bin/bash ${../scripts/sync.sh} "$invalid_config" \
+    > "$PWD/invalid-config.log" 2>&1; then
+    cat "$PWD/invalid-config.log" >&2
+    fail "runtime should reject an unsupported config schema"
+  fi
+
+  # A new copy-tree destination is installed and marked as managed.
+  fresh="$PWD/fresh"
+  mkdir -p "$fresh"
+  (
+    cd "$fresh"
+    AGENT_SKILLS_ROOT="$fresh" \
+      "${copyProgram}/bin/skills-install-local"
+  ) > "$PWD/fresh-install.log" 2>&1 || {
+    cat "$PWD/fresh-install.log" >&2
+    fail "copy-tree should install into a new destination"
+  }
+
+  fresh_dest="$fresh/.codex/skills"
+  test -f "$fresh_dest/test-skill/SKILL.md" \
+    || fail "new copy-tree destination is missing SKILL.md"
+  test -f "$fresh_dest/${markerName}" \
+    || fail "new copy-tree destination is missing its managed marker"
+  "${pkgs.jq}/bin/jq" -e 'type == "object"' "$fresh_dest/${markerName}" >/dev/null \
+    || fail "managed marker must contain valid JSON"
+
+  # Excluded paths survive synchronization. A managed read-only tree can be
+  # made writable, cleaned, and synchronized again.
+  mkdir -p "$fresh_dest/.system" "$fresh_dest/keep-me"
+  echo "system-owned" > "$fresh_dest/.system/sentinel"
+  echo "user-owned" > "$fresh_dest/keep-me/sentinel"
+  echo "stale" > "$fresh_dest/stale.txt"
+  marker_hash_before="$("${pkgs.coreutils}/bin/sha256sum" "$fresh_dest/${markerName}" | cut -d' ' -f1)"
+  chmod -R a-w "$fresh_dest"
 
   (
-    cd "$project"
-    "${installScript}/bin/skills-install-local"
-  ) > "$PWD/install.log" 2>&1
-
-  test -f "$project/.codex/skills/test-skill/SKILL.md" || {
-    echo "ERROR: copy-tree should install into an existing directory target"
-    echo "---- install.log ----"
-    cat "$PWD/install.log"
-    echo "---------------------"
-    exit 1
+    cd "$fresh"
+    AGENT_SKILLS_ROOT="$fresh" \
+      "${copyProgram}/bin/skills-install-local"
+  ) > "$PWD/read-only-resync.log" 2>&1 || {
+    cat "$PWD/read-only-resync.log" >&2
+    fail "managed read-only copy-tree should resynchronize"
   }
 
-  # should reinstall copy-tree over a read-only previously-installed tree
-  chmod -R a-w "$project/.codex/skills/test-skill"
+  test -f "$fresh_dest/test-skill/SKILL.md" \
+    || fail "read-only resynchronization lost SKILL.md"
+  test ! -e "$fresh_dest/stale.txt" \
+    || fail "read-only resynchronization did not delete an unmanaged stale file"
+  test "$(cat "$fresh_dest/.system/sentinel")" = "system-owned" \
+    || fail "default .system exclusion was not preserved"
+  test "$(cat "$fresh_dest/keep-me/sentinel")" = "user-owned" \
+    || fail "custom exclusion was not preserved"
+  test -f "$fresh_dest/${markerName}" \
+    || fail "read-only resynchronization lost the managed marker"
+
+  # Running the same synchronization again is idempotent.
   (
-    cd "$project"
-    "${installScript}/bin/skills-install-local"
-  ) > "$PWD/reinstall-readonly-copy-tree.log" 2>&1
-
-  test -f "$project/.codex/skills/test-skill/SKILL.md" || {
-    echo "ERROR: copy-tree should reinstall over read-only copied skill directories"
-    echo "---- reinstall-readonly-copy-tree.log ----"
-    cat "$PWD/reinstall-readonly-copy-tree.log"
-    echo "------------------------------------------"
-    exit 1
+    cd "$fresh"
+    AGENT_SKILLS_ROOT="$fresh" \
+      "${copyProgram}/bin/skills-install-local"
+  ) > "$PWD/idempotent-resync.log" 2>&1 || {
+    cat "$PWD/idempotent-resync.log" >&2
+    fail "repeated synchronization should succeed"
   }
+  marker_hash_after="$("${pkgs.coreutils}/bin/sha256sum" "$fresh_dest/${markerName}" | cut -d' ' -f1)"
+  test "$marker_hash_before" = "$marker_hash_after" \
+    || fail "repeated synchronization changed the managed marker"
+  test "$(cat "$fresh_dest/.system/sentinel")" = "system-owned" \
+    || fail "repeated synchronization changed excluded content"
 
-  # should sync symlink-tree over a read-only previously-copied tree
-  mkdir -p "$PWD/sync/skills/test-skill"
-  echo "# Old copied skill" > "$PWD/sync/skills/test-skill/SKILL.md"
-  mkdir -p "$PWD/sync/skills/test-skill/nested"
-  echo "old" > "$PWD/sync/skills/test-skill/nested/old.txt"
-  chmod -R a-w "$PWD/sync/skills/test-skill"
+  # A non-empty destination without a marker is rejected without modifying it.
+  unmanaged="$PWD/unmanaged"
+  unmanaged_dest="$unmanaged/.codex/skills"
+  mkdir -p "$unmanaged_dest"
+  echo "do-not-delete" > "$unmanaged_dest/SENTINEL"
+  if (
+    cd "$unmanaged"
+    AGENT_SKILLS_ROOT="$unmanaged" \
+      "${copyProgram}/bin/skills-install-local"
+  ) > "$PWD/unmanaged-reject.log" 2>&1; then
+    cat "$PWD/unmanaged-reject.log" >&2
+    fail "unmanaged non-empty destination should be rejected"
+  fi
+  test "$(cat "$unmanaged_dest/SENTINEL")" = "do-not-delete" \
+    || fail "rejected synchronization modified the unmanaged sentinel"
+  test ! -e "$unmanaged_dest/test-skill" \
+    || fail "rejected synchronization partially installed the bundle"
+  test ! -e "$unmanaged_dest/${markerName}" \
+    || fail "rejected synchronization marked an unmanaged destination"
 
-  "${syncScript}/bin/skills-sync-test" > "$PWD/sync-readonly-symlink-tree.log" 2>&1
+  # Merely creating a file with the marker name must not grant ownership.
+  printf '{}\n' > "$unmanaged_dest/${markerName}"
+  if (
+    cd "$unmanaged"
+    AGENT_SKILLS_ROOT="$unmanaged" \
+      "${copyProgram}/bin/skills-install-local"
+  ) > "$PWD/invalid-marker-reject.log" 2>&1; then
+    cat "$PWD/invalid-marker-reject.log" >&2
+    fail "destination with an invalid managed marker should be rejected"
+  fi
+  test "$(cat "$unmanaged_dest/SENTINEL")" = "do-not-delete" \
+    || fail "invalid-marker rejection modified the unmanaged sentinel"
 
-  test -L "$PWD/sync/skills/test-skill" || {
-    echo "ERROR: symlink-tree should replace read-only copied skill directory with bundle symlink"
-    echo "---- sync-readonly-symlink-tree.log ----"
-    cat "$PWD/sync-readonly-symlink-tree.log"
-    echo "----------------------------------------"
-    exit 1
+  # A symlink to a user-owned directory is not managed merely because its
+  # target is empty; only whole-destination links into /nix/store are trusted.
+  symlink_owned="$PWD/symlink-owned"
+  symlink_target="$PWD/user-owned-target"
+  mkdir -p "$symlink_owned/.codex" "$symlink_target"
+  ln -s "$symlink_target" "$symlink_owned/.codex/skills"
+  if (
+    cd "$symlink_owned"
+    AGENT_SKILLS_ROOT="$symlink_owned" \
+      "${copyProgram}/bin/skills-install-local"
+  ) > "$PWD/user-symlink-reject.log" 2>&1; then
+    cat "$PWD/user-symlink-reject.log" >&2
+    fail "symlink to a user-owned directory should be rejected"
+  fi
+  test -L "$symlink_owned/.codex/skills" \
+    || fail "rejected synchronization replaced the user-owned symlink"
+  test -z "$(find "$symlink_target" -mindepth 1 -maxdepth 1 -print -quit)" \
+    || fail "rejected synchronization modified the user-owned symlink target"
+
+  # All destinations are authorized before any target is changed.
+  preflight_root="$PWD/preflight"
+  mkdir -p "$preflight_root/second/skills"
+  echo "do-not-delete" > "$preflight_root/second/skills/SENTINEL"
+  if (
+    cd "$preflight_root"
+    AGENT_SKILLS_ROOT="$preflight_root" \
+      "${preflightProgram}/bin/skills-install-local"
+  ) > "$PWD/preflight-reject.log" 2>&1; then
+    cat "$PWD/preflight-reject.log" >&2
+    fail "multi-target synchronization should reject an unsafe destination"
+  fi
+  test ! -e "$preflight_root/first/skills" \
+    || fail "preflight failure partially installed an earlier target"
+  test "$(cat "$preflight_root/second/skills/SENTINEL")" = "do-not-delete" \
+    || fail "preflight failure modified the unsafe destination"
+
+  # Force explicitly opts into replacing the unmanaged destination.
+  (
+    cd "$unmanaged"
+    AGENT_SKILLS_ROOT="$unmanaged" AGENT_SKILLS_FORCE=1 \
+      "${copyProgram}/bin/skills-install-local"
+  ) > "$PWD/unmanaged-force.log" 2>&1 || {
+    cat "$PWD/unmanaged-force.log" >&2
+    fail "AGENT_SKILLS_FORCE=1 should replace an unmanaged destination"
   }
-  test -f "$PWD/sync/skills/test-skill/SKILL.md" || {
-    echo "ERROR: symlink-tree replacement should expose SKILL.md"
-    echo "---- sync-readonly-symlink-tree.log ----"
-    cat "$PWD/sync-readonly-symlink-tree.log"
-    echo "----------------------------------------"
-    exit 1
-  }
+  test -f "$unmanaged_dest/test-skill/SKILL.md" \
+    || fail "forced synchronization did not install SKILL.md"
+  test -f "$unmanaged_dest/${markerName}" \
+    || fail "forced synchronization did not create the managed marker"
+  test ! -e "$unmanaged_dest/SENTINEL" \
+    || fail "forced synchronization did not replace unmanaged content"
 
-  echo "copy-tree installed successfully into pre-existing directory"
-  echo "read-only destination trees are made writable before sync"
+  # Local overrides must remain beneath AGENT_SKILLS_ROOT.
+  traversal="$PWD/traversal"
+  traversal_root="$traversal/root"
+  mkdir -p "$traversal_root"
+  if (
+    cd "$traversal_root"
+    AGENT_SKILLS_ROOT="$traversal_root" \
+      AGENT_SKILLS_LOCAL_DESTS="../escaped" \
+      "${copyProgram}/bin/skills-install-local"
+  ) > "$PWD/traversal-reject.log" 2>&1; then
+    cat "$PWD/traversal-reject.log" >&2
+    fail "local ../ traversal should be rejected"
+  fi
+  test ! -e "$traversal/escaped" \
+    || fail "local traversal wrote outside AGENT_SKILLS_ROOT"
+
+  # Existing intermediate symlinks cannot redirect a local destination out of
+  # AGENT_SKILLS_ROOT.
+  symlink_escape_root="$PWD/symlink-escape/root"
+  symlink_escape_target="$PWD/symlink-escape/outside"
+  mkdir -p "$symlink_escape_root" "$symlink_escape_target"
+  ln -s "$symlink_escape_target" "$symlink_escape_root/redirect"
+  if (
+    cd "$symlink_escape_root"
+    AGENT_SKILLS_ROOT="$symlink_escape_root" \
+      AGENT_SKILLS_LOCAL_DESTS="redirect/skills" \
+      "${copyProgram}/bin/skills-install-local"
+  ) > "$PWD/intermediate-symlink-reject.log" 2>&1; then
+    cat "$PWD/intermediate-symlink-reject.log" >&2
+    fail "local destination through an escaping symlink should be rejected"
+  fi
+  test ! -e "$symlink_escape_target/skills" \
+    || fail "local destination escaped through an intermediate symlink"
+
+  # Destination data containing whitespace, quotes, and command substitution
+  # syntax is handled literally and never evaluated as shell code.
+  special_root="$PWD/special-root"
+  special_dest=${pkgs.lib.escapeShellArg specialDest}
+  mkdir -p "$special_root"
+  (
+    cd "$special_root"
+    AGENT_SKILLS_ROOT="$special_root" \
+      "${specialDestProgram}/bin/skills-install-local"
+  ) > "$PWD/special-dest.log" 2>&1 || {
+    cat "$PWD/special-dest.log" >&2
+    fail "destination containing shell metacharacters should install literally"
+  }
+  test ! -e "$special_root/PWNED" \
+    || fail "destination command substitution was executed"
+  test ! -e "$PWD/PWNED" \
+    || fail "destination command substitution escaped into the build directory"
+  test -f "$special_root/$special_dest/test-skill/SKILL.md" \
+    || fail "literal special-character destination is missing SKILL.md"
+  test -f "$special_root/$special_dest/${markerName}" \
+    || fail "literal special-character destination is missing its marker"
+
+  # link installs the whole bundle as a replaceable Nix-store symlink.
+  link_root="$PWD/link-root"
+  mkdir -p "$link_root"
+  AGENT_SKILLS_ROOT="$link_root" "${linkProgram}/bin/skills-install-local"
+  test -L "$link_root/linked-bundle" \
+    || fail "link structure did not create a destination symlink"
+  test -f "$link_root/linked-bundle/test-skill/SKILL.md" \
+    || fail "link structure does not expose the bundle"
+  AGENT_SKILLS_ROOT="$link_root" "${linkProgram}/bin/skills-install-local"
+  test -L "$link_root/linked-bundle" \
+    || fail "repeated link synchronization did not preserve the symlink"
+
+  # symlink-tree preserves bundle symlinks, exclusions, marker state, and can
+  # be run repeatedly.
+  symlink_root="$PWD/symlink-root"
+  mkdir -p "$symlink_root"
+  (
+    cd "$symlink_root"
+    unset AGENT_SKILLS_DESTS AGENT_SKILLS_TEST_HOME
+    HOME="$symlink_root" "${symlinkProgram}/bin/skills-sync-test"
+  ) > "$PWD/symlink-install.log" 2>&1 || {
+    cat "$PWD/symlink-install.log" >&2
+    fail "symlink-tree should install into a new destination"
+  }
+  symlink_dest="$symlink_root/sync/skills"
+  test -L "$symlink_dest/test-skill" \
+    || fail "symlink-tree should preserve the bundle skill symlink"
+  test -f "$symlink_dest/test-skill/SKILL.md" \
+    || fail "symlink-tree target does not expose SKILL.md"
+  test -f "$symlink_dest/${markerName}" \
+    || fail "symlink-tree destination is missing its managed marker"
+
+  mkdir -p "$symlink_dest/.system" "$symlink_dest/keep-me"
+  echo "system-owned" > "$symlink_dest/.system/sentinel"
+  echo "user-owned" > "$symlink_dest/keep-me/sentinel"
+  (
+    cd "$symlink_root"
+    unset AGENT_SKILLS_DESTS AGENT_SKILLS_TEST_HOME
+    HOME="$symlink_root" "${symlinkProgram}/bin/skills-sync-test"
+  ) > "$PWD/symlink-resync.log" 2>&1 || {
+    cat "$PWD/symlink-resync.log" >&2
+    fail "repeated symlink-tree synchronization should succeed"
+  }
+  test -L "$symlink_dest/test-skill" \
+    || fail "repeated symlink-tree synchronization replaced the skill link"
+  test "$(cat "$symlink_dest/.system/sentinel")" = "system-owned" \
+    || fail "symlink-tree did not preserve the default exclusion"
+  test "$(cat "$symlink_dest/keep-me/sentinel")" = "user-owned" \
+    || fail "symlink-tree did not preserve the custom exclusion"
+
+  # A non-empty environment value wins over the $HOME fallback without eval.
+  configured_root="$PWD/configured-root"
+  mkdir -p "$configured_root"
+  unset AGENT_SKILLS_DESTS
+  AGENT_SKILLS_TEST_HOME="$configured_root" \
+    HOME="$symlink_root" "${symlinkProgram}/bin/skills-sync-test"
+  test -L "$configured_root/skills/test-skill" \
+    || fail "global destination did not honor its configured environment root"
+
+  override_root="$PWD/global-override"
+  mkdir -p "$override_root"
+  AGENT_SKILLS_DESTS="$override_root/skills" \
+    HOME="$symlink_root" "${symlinkProgram}/bin/skills-sync-test"
+  test -L "$override_root/skills/test-skill" \
+    || fail "global destination override was not synchronized"
+
   mkdir -p "$out"
   touch "$out/ok"
 ''


### PR DESCRIPTION
## Summary

- Move the global and project-local synchronization logic out of `lib/default.nix` into a shared, static `scripts/sync.sh` runtime.
- Add `mkSyncProgram` and `mkLocalInstallProgram`, with a versioned JSON configuration boundary between Nix and the runtime.
- Keep `mkSyncScript` and `mkLocalInstallScript` as compatibility wrappers so existing consumer flakes retain their current call patterns and return types.
- Route the root flake apps, Home Manager activation, `mkShellHook`, and examples through the shared runtime.
- Add destination ownership markers, path-containment checks, preflight validation, safe limited global path expansion, and literal handling of shell metacharacters.
- Add integration coverage, consumer API compatibility coverage, and a ShellCheck flake check.

## Why

The synchronization behavior was duplicated as large inline shell fragments inside `lib/default.nix`. That made the Nix file difficult to review, allowed the local and global implementations to drift, and mixed destination data with generated shell source.

A single runtime with a JSON boundary makes the synchronization contract explicit and testable while reducing `lib/default.nix` from roughly 790 lines to 615 lines.

## User impact

Existing Home Manager configuration, flake app names, package names, and direct helper call patterns remain valid.

Tree destinations are now marked with `.agent-skills-managed.json`. An existing non-empty destination created by an older release has no marker, so users should inspect it and use `AGENT_SKILLS_FORCE=1` once to adopt it.

Runtime expansion is intentionally limited to `$HOME`, `~`, and `${VAR:-$HOME/...}` forms; destination strings are no longer evaluated as general shell code.

## Validation

- `nix flake check "path:$PWD" --print-build-logs`
- sync integration coverage for copy/link/symlink trees, markers, force takeover, read-only resync, exclusions, traversal, symlinks, overrides, metacharacters, and multi-target preflight
- consumer API compatibility build/run test
- ShellCheck
- `bash -n scripts/sync.sh`
- `git diff --check`
