### PR TITLE
refactor: organize flake outputs with Blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Notes:
 - `homeManagerModules.default`: Home Manager module implementing the DSL above.
 - `lib.agent-skills`: Helper functions (`discoverCatalog`, `selectSkills`, `mkBundle`, `mkSyncProgram`, `mkLocalInstallProgram`, compatibility wrappers `mkSyncScript` / `mkLocalInstallScript`, `mkShellHook`, `catalogJson`, `defaultConfig`).
 
+## Development structure
+
+The root `flake.nix` only declares inputs and invokes [Blueprint](https://github.com/numtide/blueprint). Blueprint discovers packages, checks, and the public library under `nix/`; `nix/flake-outputs.nix` projects those pieces onto the existing public output names and wires the apps and Home Manager module. Runtime and domain logic remain in `scripts/`, `lib/`, `modules/`, and `test/`.
+
 ## Library functions
 
 See [`examples/library-functions/snippet.nix`](./examples/library-functions/snippet.nix).

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -38,8 +59,24 @@
     },
     "root": {
       "inputs": {
+        "blueprint": "blueprint",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,10 @@
   description = "Declarative Agent Skills management with flake-pinned sources and Home Manager integration";
 
   inputs = {
+    blueprint = {
+      url = "github:numtide/blueprint";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     home-manager = {
       url = "github:nix-community/home-manager";
@@ -9,129 +13,13 @@
     };
   };
 
-  outputs = inputs@{ self, nixpkgs, home-manager, ... }:
+  outputs = inputs:
     let
-      systems = [
-        "x86_64-linux"
-        "aarch64-linux"
-        "x86_64-darwin"
-        "aarch64-darwin"
-      ];
-
-      forAllSystems = nixpkgs.lib.genAttrs systems;
-      lib = import ./lib {
-        lib = nixpkgs.lib;
+      blueprint = inputs.blueprint {
         inherit inputs;
+        prefix = "nix";
+        systems = import ./nix/systems.nix;
       };
-
-      # Default global targets are defined in lib/default.nix; see README.md#default-target-paths.
-      defaultTargets = lib.defaultTargets;
-
-      # Default local targets are defined in lib/default.nix; see README.md#default-target-paths.
-      defaultLocalTargets = lib.defaultLocalTargets;
-
-      defaultConfig = {
-        # Add sources and skills (enable/explicit) in your consumer flake; kept empty here to stay neutral.
-        sources = {};
-        skills = {
-          enable = [];
-          enableAll = false;
-          explicit = {};
-        };
-        targets = defaultTargets;
-        excludePatterns = lib.defaultExcludePatterns;
-      };
-
-      defaultCatalog = lib.discoverCatalog defaultConfig.sources;
-      defaultAllowlist = lib.allowlistFor {
-        catalog = defaultCatalog;
-        sources = defaultConfig.sources;
-        enableAll = defaultConfig.skills.enableAll;
-        enable = defaultConfig.skills.enable;
-      };
-      defaultSelection = lib.selectSkills {
-        catalog = defaultCatalog;
-        allowlist = defaultAllowlist;
-        skills = defaultConfig.skills.explicit;
-        sources = defaultConfig.sources;
-      };
-
-      bundleFor = system:
-        let pkgs = nixpkgs.legacyPackages.${system}; in
-        lib.mkBundle { inherit pkgs; selection = defaultSelection; name = "agent-skills-bundle"; };
     in
-    {
-      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixpkgs-fmt);
-
-      packages = forAllSystems (system: let
-        bundle = bundleFor system;
-      in {
-        agent-skills-bundle = bundle;
-        default = bundle;
-      });
-
-      apps = forAllSystems (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          bundle = bundleFor system;
-          listJson = pkgs.writeText "agent-skills-catalog.json" (builtins.toJSON (lib.catalogJson defaultCatalog));
-
-          installProgram = lib.mkSyncProgram {
-            inherit pkgs bundle;
-            targets = defaultTargets;
-            system = pkgs.stdenv.hostPlatform.system;
-            allowOverrides = true;
-          };
-
-          listScript = pkgs.writeShellApplication {
-            name = "skills-list";
-            runtimeInputs = [ pkgs.jq pkgs.coreutils ];
-            text = ''
-              cat ${listJson} | ${pkgs.jq}/bin/jq .
-            '';
-          };
-
-          installLocalProgram = lib.mkLocalInstallProgram {
-            inherit pkgs bundle;
-            targets = defaultLocalTargets;
-          };
-        in {
-          skills-install = {
-            type = "app";
-            program = "${installProgram}/bin/skills-install";
-          };
-          skills-install-local = {
-            type = "app";
-            program = "${installLocalProgram}/bin/skills-install-local";
-          };
-          skills-list = {
-            type = "app";
-            program = "${listScript}/bin/skills-list";
-          };
-        });
-
-      checks = forAllSystems (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          bundle = bundleFor system;
-          agentSkillsModule = import ./modules/home-manager/agent-skills.nix {
-            inherit inputs;
-            lib = nixpkgs.lib;
-          };
-        in
-        import ./test {
-          inherit pkgs bundle agentSkillsModule;
-          agentLib = lib;
-          hmLib = home-manager.lib;
-        });
-
-      homeManagerModules.default =
-        import ./modules/home-manager/agent-skills.nix {
-          inherit inputs;
-          lib = nixpkgs.lib;
-        };
-
-      lib.agent-skills = lib // { defaultConfig = defaultConfig; };
-      catalog = lib.catalogJson defaultCatalog;
-    };
+    import ./nix/flake-outputs.nix { inherit blueprint inputs; };
 }

--- a/nix/apps.nix
+++ b/nix/apps.nix
@@ -1,0 +1,58 @@
+{ blueprint
+, inputs
+, systems
+,
+}:
+
+let
+  agentLib = blueprint.lib.agent-skills;
+  config = agentLib.defaultConfig;
+  catalog = agentLib.discoverCatalog config.sources;
+in
+inputs.nixpkgs.lib.genAttrs systems (
+  system:
+  let
+    pkgs = inputs.nixpkgs.legacyPackages.${system};
+    bundle = blueprint.packages.${system}.agent-skills-bundle;
+    listJson = pkgs.writeText "agent-skills-catalog.json" (
+      builtins.toJSON (agentLib.catalogJson catalog)
+    );
+
+    installProgram = agentLib.mkSyncProgram {
+      inherit pkgs bundle;
+      targets = config.targets;
+      system = pkgs.stdenv.hostPlatform.system;
+      allowOverrides = true;
+    };
+
+    installLocalProgram = agentLib.mkLocalInstallProgram {
+      inherit pkgs bundle;
+      targets = agentLib.defaultLocalTargets;
+    };
+
+    listScript = pkgs.writeShellApplication {
+      name = "skills-list";
+      runtimeInputs = [
+        pkgs.jq
+        pkgs.coreutils
+      ];
+      text = ''
+        cat ${listJson} | ${pkgs.jq}/bin/jq .
+      '';
+    };
+  in
+  {
+    skills-install = {
+      type = "app";
+      program = "${installProgram}/bin/skills-install";
+    };
+    skills-install-local = {
+      type = "app";
+      program = "${installLocalProgram}/bin/skills-install-local";
+    };
+    skills-list = {
+      type = "app";
+      program = "${listScript}/bin/skills-list";
+    };
+  }
+)

--- a/nix/checks/compatibility.nix
+++ b/nix/checks/compatibility.nix
@@ -1,0 +1,1 @@
+args: (import ../internal/checks.nix args).compatibility

--- a/nix/checks/discover.nix
+++ b/nix/checks/discover.nix
@@ -1,0 +1,1 @@
+args: (import ../internal/checks.nix args).discover

--- a/nix/checks/home-manager-input-source.nix
+++ b/nix/checks/home-manager-input-source.nix
@@ -1,0 +1,1 @@
+args: (import ../internal/checks.nix args).home-manager-input-source

--- a/nix/checks/home-manager-warnings.nix
+++ b/nix/checks/home-manager-warnings.nix
@@ -1,0 +1,1 @@
+args: (import ../internal/checks.nix args).home-manager-warnings

--- a/nix/checks/local-install-script.nix
+++ b/nix/checks/local-install-script.nix
@@ -1,0 +1,1 @@
+args: (import ../internal/checks.nix args).local-install-script

--- a/nix/checks/skills.nix
+++ b/nix/checks/skills.nix
@@ -1,0 +1,1 @@
+args: (import ../internal/checks.nix args).skills

--- a/nix/checks/sync-shellcheck.nix
+++ b/nix/checks/sync-shellcheck.nix
@@ -1,0 +1,1 @@
+args: (import ../internal/checks.nix args).sync-shellcheck

--- a/nix/checks/targets.nix
+++ b/nix/checks/targets.nix
@@ -1,0 +1,1 @@
+args: (import ../internal/checks.nix args).targets

--- a/nix/checks/transform-packages.nix
+++ b/nix/checks/transform-packages.nix
@@ -1,0 +1,1 @@
+args: (import ../internal/checks.nix args).transform-packages

--- a/nix/default-config.nix
+++ b/nix/default-config.nix
@@ -1,0 +1,13 @@
+{ agentLib }:
+
+{
+  # Consumer flakes add their own sources and selection. The root flake stays neutral.
+  sources = { };
+  skills = {
+    enable = [ ];
+    enableAll = false;
+    explicit = { };
+  };
+  targets = agentLib.defaultTargets;
+  excludePatterns = agentLib.defaultExcludePatterns;
+}

--- a/nix/flake-outputs.nix
+++ b/nix/flake-outputs.nix
@@ -1,0 +1,44 @@
+{ blueprint, inputs }:
+
+let
+  inherit (inputs.nixpkgs) lib;
+  systems = import ./systems.nix;
+  checkNames = [
+    "compatibility"
+    "discover"
+    "home-manager-input-source"
+    "home-manager-warnings"
+    "local-install-script"
+    "skills"
+    "sync-shellcheck"
+    "targets"
+    "transform-packages"
+  ];
+  packageNames = [
+    "agent-skills-bundle"
+    "default"
+  ];
+
+  agentLib = blueprint.lib.agent-skills;
+  defaultCatalog = agentLib.discoverCatalog agentLib.defaultConfig.sources;
+in
+{
+  formatter = lib.genAttrs systems (
+    system: inputs.nixpkgs.legacyPackages.${system}.nixpkgs-fmt
+  );
+
+  packages = lib.genAttrs systems (
+    system: lib.getAttrs packageNames blueprint.packages.${system}
+  );
+
+  apps = import ./apps.nix { inherit blueprint inputs systems; };
+
+  checks = lib.genAttrs systems (
+    system: lib.getAttrs checkNames blueprint.checks.${system}
+  );
+
+  homeManagerModules.default = import ./home-manager-module.nix { inherit inputs; };
+
+  inherit (blueprint) lib;
+  catalog = agentLib.catalogJson defaultCatalog;
+}

--- a/nix/home-manager-module.nix
+++ b/nix/home-manager-module.nix
@@ -1,0 +1,6 @@
+{ inputs }:
+
+import ../modules/home-manager/agent-skills.nix {
+  inherit inputs;
+  lib = inputs.nixpkgs.lib;
+}

--- a/nix/internal/checks.nix
+++ b/nix/internal/checks.nix
@@ -1,0 +1,14 @@
+{ flake
+, inputs
+, perSystem
+, pkgs
+, ...
+}:
+
+import ../../test {
+  inherit pkgs;
+  agentLib = flake.lib.agent-skills;
+  hmLib = inputs.home-manager.lib;
+  agentSkillsModule = flake.homeManagerModules.default;
+  bundle = perSystem.self.agent-skills-bundle;
+}

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -1,0 +1,12 @@
+{ inputs, ... }:
+
+let
+  agentLib = import ../../lib {
+    lib = inputs.nixpkgs.lib;
+    inherit inputs;
+  };
+  defaultConfig = import ../default-config.nix { inherit agentLib; };
+in
+{
+  agent-skills = agentLib // { inherit defaultConfig; };
+}

--- a/nix/packages/agent-skills-bundle.nix
+++ b/nix/packages/agent-skills-bundle.nix
@@ -1,0 +1,22 @@
+{ flake, pkgs, ... }:
+
+let
+  agentLib = flake.lib.agent-skills;
+  config = agentLib.defaultConfig;
+  catalog = agentLib.discoverCatalog config.sources;
+  allowlist = agentLib.allowlistFor {
+    inherit catalog;
+    sources = config.sources;
+    enableAll = config.skills.enableAll;
+    enable = config.skills.enable;
+  };
+  selection = agentLib.selectSkills {
+    inherit catalog allowlist;
+    skills = config.skills.explicit;
+    sources = config.sources;
+  };
+in
+agentLib.mkBundle {
+  inherit pkgs selection;
+  name = "agent-skills-bundle";
+}

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -1,0 +1,3 @@
+{ perSystem, ... }:
+
+perSystem.self.agent-skills-bundle

--- a/nix/systems.nix
+++ b/nix/systems.nix
@@ -1,0 +1,6 @@
+[
+  "x86_64-linux"
+  "aarch64-linux"
+  "x86_64-darwin"
+  "aarch64-darwin"
+]


### PR DESCRIPTION
## Summary

- Add `numtide/blueprint` and reduce the root `flake.nix` to input declaration plus output composition.
- Move packages, checks, the public library, default configuration, systems, apps, and Home Manager wiring into focused files under `nix/`.
- Use Blueprint discovery for packages, checks, and `lib`, then explicitly project only the repository's established public outputs.
- Keep the existing `homeManagerModules.default` spelling and app names even though they are not Blueprint's native folder outputs.

## Why

The root flake mixed system iteration, default configuration, package construction, apps, tests, modules, and public output shaping in one file. Blueprint provides the preferred lightweight discovery structure while a small explicit adapter preserves this project's existing public contract.

## User impact

Existing consumer `flake.nix` and Home Manager configuration do not need to change. Top-level output names, per-system package/app/check names, helper attributes, default configuration, catalog value, and native derivation/program paths were compared against the parent PR and are identical.

This is stacked on #53, which is stacked on #52.

## Validation

- `nix flake check "path:$PWD"`
- explicit build/evaluation of all nine native-system checks
- old/new output topology comparison for every configured system
- value-level comparison of packages, apps, checks, formatter, `lib.agent-skills`, `defaultConfig`, `catalog`, and the Home Manager module type
- formatter and `git diff --check`
