### PR TITLE
feat(sync): add quiet mode for installation progress lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,11 @@ See [`examples/devshell/flake.nix`](./examples/devshell/flake.nix).
 
 Now `nix develop` will automatically install skills to your project directory.
 
+The hook prints one line per installed target. Under direnv the hook is
+re-evaluated on every shell entry, so pass `quiet = true;` to `mkShellHook` to
+drop those lines; warnings and failures still go to stderr. `AGENT_SKILLS_QUIET=1`
+does the same for any synchronization program at runtime.
+
 ## Symlinks inside skills
 
 Symlinks inside skill directories are kept when their textual target stays inside the declared source root (e.g. `../shared` to a sibling at the root). Symlinks whose target escapes the root are dropped, along with any links left dangling by that drop.

--- a/lib/targets.nix
+++ b/lib/targets.nix
@@ -187,12 +187,15 @@ let
 
   # Create a shellHook string for use in devShells.
   # Automatically installs skills when entering the dev shell.
-  mkShellHook = { pkgs, bundle, targets ? defaultLocalTargets, excludePatterns ? defaultExcludePatterns }:
+  # Set quiet when the shell is entered often, e.g. through direnv, where the
+  # per-target progress lines would otherwise print at every shell entry;
+  # warnings and failures still reach stderr.
+  mkShellHook = { pkgs, bundle, targets ? defaultLocalTargets, excludePatterns ? defaultExcludePatterns, quiet ? false }:
     let
       installProgram = mkLocalInstallProgram { inherit pkgs bundle targets excludePatterns; };
     in
     ''
-      ${installProgram}/bin/skills-install-local
+      ${lib.optionalString quiet "AGENT_SKILLS_QUIET=1 "}${installProgram}/bin/skills-install-local
     '';
 in
 {

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -14,6 +14,16 @@ warn() {
   printf '%s: %s\n' "$PROGRAM_NAME" "$*" >&2
 }
 
+# Progress lines are printed on every synchronization, so a devShell hook run
+# from direnv repeats them at every shell entry. Quiet mode drops those lines
+# only; warnings and failures keep their stderr output.
+quiet() {
+  case "${AGENT_SKILLS_QUIET:-}" in
+    1 | true | yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 require_command() {
   command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
@@ -316,7 +326,7 @@ sync_destination() {
       ;;
   esac
 
-  printf '%s: installed %s to %s\n' "$PROGRAM_NAME" "$target_name" "$destination"
+  quiet || printf '%s: installed %s to %s\n' "$PROGRAM_NAME" "$target_name" "$destination"
 }
 
 [ "$#" -eq 1 ] || die "usage: sync.sh CONFIG_JSON_PATH"

--- a/test/local-install-script.nix
+++ b/test/local-install-script.nix
@@ -143,6 +143,25 @@ pkgs.runCommand "agent-skills-sync-program-integration-test" { } ''
   "${pkgs.jq}/bin/jq" -e 'type == "object"' "$fresh_dest/${markerName}" >/dev/null \
     || fail "managed marker must contain valid JSON"
 
+  grep -q "installed codex to $fresh_dest" "$PWD/fresh-install.log" \
+    || fail "synchronization should report installed targets by default"
+
+  # Quiet mode drops the progress lines but still synchronizes the tree.
+  echo "stale" > "$fresh_dest/quiet-stale.txt"
+  (
+    cd "$fresh"
+    AGENT_SKILLS_ROOT="$fresh" AGENT_SKILLS_QUIET=1 \
+      "${copyProgram}/bin/skills-install-local"
+  ) > "$PWD/quiet-install.log" 2>&1 || {
+    cat "$PWD/quiet-install.log" >&2
+    fail "quiet synchronization should succeed"
+  }
+
+  test ! -s "$PWD/quiet-install.log" \
+    || fail "quiet synchronization should print nothing on success"
+  test ! -e "$fresh_dest/quiet-stale.txt" \
+    || fail "quiet synchronization did not synchronize the destination"
+
   # Excluded paths survive synchronization. A managed read-only tree can be
   # made writable, cleaned, and synchronized again.
   mkdir -p "$fresh_dest/.system" "$fresh_dest/keep-me"


### PR DESCRIPTION
## Problem

`mkShellHook` runs the local install program on devshell entry. With a plain `use flake` `.envrc`, direnv re-evaluates the hook on **every** shell entry, so `agent-skills: installed <target> to <path>` is reprinted at every prompt:

```
agent-skills: installed agents to /path/to/repo/.agents/skills
agent-skills: installed claude to /path/to/repo/.claude/skills
```

The line carries no new information after the first sync, and there is currently no way to turn it off other than redirecting the whole hook to `/dev/null` in the consumer flake — which would also swallow diagnostics.

## Change

An opt-in quiet mode that suppresses the per-target progress lines only:

- `scripts/sync.sh` honours `AGENT_SKILLS_QUIET` (`1` / `true` / `yes`) at runtime, so it applies to `skills-install` and `skills-install-local` when invoked directly too.
- `lib/targets.nix`: `mkShellHook` gains `quiet ? false`, which sets that variable for the hook invocation.

Warnings and failures are untouched — they still go to stderr. The config JSON schema is unchanged, so no `schemaVersion` bump.

```nix
shellHook = agentLib.mkShellHook { inherit pkgs bundle; targets = localTargets; quiet = true; };
```

## Tests

`test/local-install-script.nix` asserts both directions: the default run reports the installed target, and a `AGENT_SKILLS_QUIET=1` run prints nothing while still synchronizing the destination (a stale file planted beforehand is removed).

`nix flake check` passes locally on `aarch64-darwin`.